### PR TITLE
Bunch of stuff

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^0.1.3
+  cupertino_icons: ^1.0.0 # was ^0.1.3
   http: ^0.12.1
   xml: ^4.3.0
   flutter_launcher_icons: ^0.7.5
@@ -31,7 +31,8 @@ dependencies:
   image: ^2.1.18
   google_fonts: ^1.1.0
   url_launcher: ^5.5.0
-  video_player: 0.10.11+2
+  video_player: 0.11.1+4 # this is the last version without the need to update sdk, was 0.10.11+2
+  chewie: ^0.10.4 # last version is 0.12.1+1, but it requires to update sdk, video_player and cupertino_icons
   preload_page_view: ^0.1.4
   flutter_icons:
 flutter_icons:


### PR DESCRIPTION
Features/changes:
- added chewie for video controls, autoplay, looping...
- upped versions of cupertino_icons and video_player dependencies (see pubspec for comments on them)
- videos will autoplay when viewed and autostop when scrolled to the next
- when viewing videos, show their dimensions on the bottom
- snackbars when loading next page or when added tag to search/created new tab
- loading progress to thumbnails and viewer (except videos)
- scrollbar on GridView
- scroll GridView to current item in viewer, this will also trigger next page load when you reach last available rows
- show current/total items counter in viewer
- increased maxScale on images to 8

Fixes:
- set tag search results height to 300, otherwise it was overflowing when > 5 results
- couldn't trigger next page load if first page didn't fill the screen (example: too many thumbnails per row)
- force thumbnailURL on gifs too, (sampleURL can be a gif itself, this will tank the performance)
- don't render empty tag list entries
- don't render items in viewer when they aren't in preloadCount range (I'm not sure if this will affect how the app retrieves these images when returning to them later, probably will force reload when out of range for too long)