### PR TITLE
Get both inboxed and archived files from Hydrus

### DIFF
--- a/lib/libBooru/HydrusHandler.dart
+++ b/lib/libBooru/HydrusHandler.dart
@@ -30,7 +30,7 @@ class HydrusHandler extends BooruHandler{
     }
     this.pageNum = pageNum;
     if (prevTags != tags){
-      print("maknig new fetched list");
+      print("making new fetched list");
       fetched = new List();
       prevTags = tags;
     }
@@ -131,7 +131,7 @@ class HydrusHandler extends BooruHandler{
       } else {
         tag = "[${jsonEncode(tags)}]";
       }
-      return "${booru.baseURL}/get_files/search_files?system_inbox=true&system_archive=true&tags=$tag";
+      return "${booru.baseURL}/get_files/search_files?tags=$tag";
     }
     String makeTagURL(String input){
       return "${booru.baseURL}/index.php?page=dapi&s=tag&q=index&name_pattern=$input%&limit=5";


### PR DESCRIPTION
The `get_files/search_files` API endpoint is a bit odd and the way to get _all_ files is for both `system_inbox` and `system_archive` to be false (or omitted). When they are both true it returns only inboxed files.