### PR TITLE
Bunch of stuff

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -45,6 +45,16 @@
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
+
+        <provider
+          android:name="androidx.core.content.FileProvider"
+          android:authorities="${applicationId}.fileprovider"
+          android:exported="false"
+          android:grantUriPermissions="true">
+          <meta-data
+              android:name="android.support.FILE_PROVIDER_PATHS"
+              android:resource="@xml/provider_paths" />
+        </provider>
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
         <meta-data

--- a/android/app/src/main/res/xml/provider_paths.xml
+++ b/android/app/src/main/res/xml/provider_paths.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <cache-path name="cache" path="."/>
+</paths>

--- a/lib/AboutPage.dart
+++ b/lib/AboutPage.dart
@@ -28,15 +28,17 @@ class AboutPage extends StatelessWidget {
             ),
             Container(
               alignment: Alignment.center,
-              child: FlatButton(
-                shape: RoundedRectangleBorder(
-                  borderRadius: new BorderRadius.circular(20),
-                  side: BorderSide(color: Get.context!.theme.accentColor),
+              child: TextButton(
+                style: TextButton.styleFrom(
+                    shape: RoundedRectangleBorder(
+                      borderRadius: new BorderRadius.circular(20),
+                      side: BorderSide(color: Get.context!.theme.accentColor),
+                    ),
                 ),
                 onPressed: (){
                   ServiceHandler.launchURL("https://github.com/NO-ob/LoliSnatcher_Droid");
                 },
-                child: Text("GitHub"),
+                child: Text('GitHub', style: TextStyle(color: Colors.white))
               ),
             ),
             Container(
@@ -44,15 +46,17 @@ class AboutPage extends StatelessWidget {
               child: Text("A big thanks to Showers-U for letting me use their artwork for the app logo please check them out on pixiv"),),
             Container(
               alignment: Alignment.center,
-              child: FlatButton(
-                shape: RoundedRectangleBorder(
-                  borderRadius: new BorderRadius.circular(20),
-                  side: BorderSide(color: Get.context!.theme.accentColor,),
+              child: TextButton(
+                style: TextButton.styleFrom(
+                    shape: RoundedRectangleBorder(
+                      borderRadius: new BorderRadius.circular(20),
+                      side: BorderSide(color: Get.context!.theme.accentColor),
+                    ),
                 ),
                 onPressed: (){
                   ServiceHandler.launchURL("https://www.pixiv.net/en/users/28366691");
                 },
-                child: Text("Showers-U - Pixiv"),
+                child: Text("Showers-U - Pixiv", style: TextStyle(color: Colors.white)),
               ),
             ),
             Container(
@@ -60,15 +64,17 @@ class AboutPage extends StatelessWidget {
               child: Text("A big thanks to NANI-SORE for fixing a bunch of bugs and adding some needed features"),),
             Container(
               alignment: Alignment.center,
-              child: FlatButton(
-                shape: RoundedRectangleBorder(
-                  borderRadius: new BorderRadius.circular(20),
-                  side: BorderSide(color: Get.context!.theme.accentColor,),
+              child: TextButton(
+                style: TextButton.styleFrom(
+                    shape: RoundedRectangleBorder(
+                      borderRadius: new BorderRadius.circular(20),
+                      side: BorderSide(color: Get.context!.theme.accentColor),
+                    ),
                 ),
                 onPressed: (){
                   ServiceHandler.launchURL("https://github.com/NANI-SORE");
                 },
-                child: Text("NANI-SORE - Github"),
+                child: Text("NANI-SORE - Github", style: TextStyle(color: Colors.white)),
               ),
             )
           ],

--- a/lib/ServiceHandler.dart
+++ b/lib/ServiceHandler.dart
@@ -67,11 +67,23 @@ class ServiceHandler{
     }
     return result;
   }
-  void loadShareIntent(String fileURL) async{
+  Future<void> loadShareTextIntent(String text) async{
     try{
-      await platform.invokeMethod("shareItem",{"fileURL": fileURL});
+      await platform.invokeMethod("shareText",{"text": text});
+      return;
     } catch(e){
       print(e);
+      return;
+    }
+  }
+  Future<void> loadShareFileIntent(String filePath, String mimeType) async{
+    try{
+      await platform.invokeMethod("shareFile", {"path": filePath, "mimeType": mimeType});
+      return;
+      // print('share closed');
+    } catch(e){
+      print(e);
+      return;
     }
   }
   static void displayToast (String str){

--- a/lib/SettingsHandler.dart
+++ b/lib/SettingsHandler.dart
@@ -16,7 +16,7 @@ import 'libBooru/DBHandler.dart';
 class SettingsHandler {
   ServiceHandler serviceHandler = new ServiceHandler();
   DBHandler dbHandler = new DBHandler();
-  String? defTags = "rating:safe", previewMode = "Sample", videoCacheMode = "Stream", prefBooru = "", cachePath = "", previewDisplay = "Waterfall", galleryMode="Full Res";
+  String? defTags = "rating:safe", previewMode = "Sample", videoCacheMode = "Stream", prefBooru = "", cachePath = "", previewDisplay = "Waterfall", galleryMode="Full Res", shareAction = "Ask";
   int limit = 20, portraitColumns = 2,landscapeColumns = 4, preloadCount = 2, snatchCooldown = 250;
   int SDKVer = 0;
   String verStr = "1.7.7";
@@ -156,6 +156,12 @@ class SettingsHandler {
               print("Found Video Cache Mode " + settings[i].split(" = ")[1] );
             }
             break;
+          case("Share Action"):
+            if (settings[i].split(" = ").length > 1){
+              shareAction = settings[i].split(" = ")[1];
+              print("Found Share Action " + settings[i].split(" = ")[1] );
+            }
+            break;
           case("Pref Booru"):
             if (settings[i].split(" = ").length > 1){
               prefBooru = settings[i].split(" = ")[1];
@@ -212,7 +218,7 @@ class SettingsHandler {
     return true;
   }
   //to-do: Change to scoped storage to be compliant with googles new rules https://www.androidcentral.com/what-scoped-storage
-  void saveSettings(String defTags, String limit, String previewMode, String portraitColumns, String landscapeColumns, String preloadCount,bool jsonWrite, String prefBooru, bool autoPlay, bool loadingGif, bool imageCache, bool mediaCache, String videoCacheMode, bool autoHideImageBar, String snatchCooldown, String previewDisplay, String galleryMode, bool dbEnabled) async{
+  void saveSettings(String defTags, String limit, String previewMode, String portraitColumns, String landscapeColumns, String preloadCount,bool jsonWrite, String prefBooru, bool autoPlay, bool loadingGif, bool imageCache, bool mediaCache, String videoCacheMode, bool autoHideImageBar, String snatchCooldown, String previewDisplay, String galleryMode, bool dbEnabled, String shareAction) async{
     if (path == ""){
      path = await getExtDir();
     }
@@ -262,6 +268,8 @@ class SettingsHandler {
     }
     writer.write("Video Cache Mode = $videoCacheMode\n");
     this.videoCacheMode = videoCacheMode;
+    writer.write("Share Action = $shareAction\n");
+    this.shareAction = shareAction;
     writer.write("Autohide Bar = $autoHideImageBar\n");
     this.autoHideImageBar = autoHideImageBar;
     writer.write("Snatch Cooldown  = $snatchCooldown\n");

--- a/lib/SettingsPage.dart
+++ b/lib/SettingsPage.dart
@@ -40,7 +40,7 @@ class _SettingsPageState extends State<SettingsPage> {
   final settingsSnatchCooldownController = TextEditingController();
   bool jsonWrite = false, autoPlay = true, loadingGif = false, imageCache = false, mediaCache = false, autoHideImageBar = false, dbEnabled = true;
   Booru? selectedBooru;
-  String? previewMode, videoCacheMode,previewDisplay,galleryMode;
+  String? previewMode, videoCacheMode, previewDisplay, galleryMode, shareAction;
   @override
   // These lines are done in init state as they only need to be run once when the widget is first loaded
   void initState() {
@@ -57,6 +57,7 @@ class _SettingsPageState extends State<SettingsPage> {
     previewDisplay = widget.settingsHandler.previewDisplay;
     videoCacheMode = widget.settingsHandler.videoCacheMode;
     galleryMode = widget.settingsHandler.galleryMode;
+    shareAction = widget.settingsHandler.shareAction;
     getPerms();
     setState(() {
       jsonWrite = widget.settingsHandler.jsonWrite;
@@ -228,6 +229,50 @@ class _SettingsPageState extends State<SettingsPage> {
             ),
             Container(
               width: double.infinity,
+              margin: EdgeInsets.fromLTRB(10, 2, 10, 2),
+              child: Row(
+                mainAxisSize: MainAxisSize.max,
+                children: <Widget>[
+                  Text("Default Share Action :     "),
+                  DropdownButton<String>(
+                    value: shareAction,
+                    icon: Icon(Icons.arrow_downward),
+                    onChanged: (String? newValue){
+                      setState((){
+                        shareAction = newValue;
+                      });
+                    },
+                    items: <String>["Ask", "Post URL", "File URL", "File"].map<DropdownMenuItem<String>>((String value){
+                      return DropdownMenuItem<String>(
+                        value: value,
+                        child: Text(value),
+                      );
+                    }).toList(),
+                  ),
+                  IconButton(
+                    icon: Icon(Icons.info, color: Get.context!.theme.accentColor),
+                    onPressed: () {
+                        Get.dialog(
+                          InfoDialog("Share Actions",
+                            [
+                              Text("- Ask - always ask what to share"),
+                              Text("- Post URL"),
+                              Text("- File URL - shares direct link to the original file (may not work with some sites, e.g. Sankaku)"),
+                              Text("- File - shares viewed file itself"),
+                              const SizedBox(height: 10),
+                              Text("[Note]: If File is saved in cache, it will be loaded from there. Otherwise it will be loaded again from network which can take some time."),
+                              Text("[Tip]: You can open Share Actions Menu by long pressing Share button")
+                            ],
+                            CrossAxisAlignment.start,
+                          )
+                        );
+                    },
+                  ),
+                ],
+              ),
+            ),
+            Container(
+              width: double.infinity,
               margin: EdgeInsets.fromLTRB(10,10,10,10),
               child: Row(
                 mainAxisSize: MainAxisSize.max,
@@ -292,7 +337,8 @@ class _SettingsPageState extends State<SettingsPage> {
                               [
                                 Text("The database will store favourites and also track if an item is snatched"),
                                 Text("If an item is snatched it wont be snatched again"),
-                              ]
+                              ],
+                              CrossAxisAlignment.start,
                           )
                       );
                     },
@@ -302,26 +348,30 @@ class _SettingsPageState extends State<SettingsPage> {
             Container(
               alignment: Alignment.centerLeft,
               margin: EdgeInsets.fromLTRB(20,10,20,10),
-              child: FlatButton(
-                shape: RoundedRectangleBorder(
-                  borderRadius: new BorderRadius.circular(20),
-                  side: BorderSide(color: Get.context!.theme.accentColor),
+              child: TextButton(
+                style: TextButton.styleFrom(
+                  shape: RoundedRectangleBorder(
+                    borderRadius: new BorderRadius.circular(20),
+                    side: BorderSide(color: Get.context!.theme.accentColor),
+                  ),
                 ),
                 onPressed: (){
                   serviceHandler.deleteDB(widget.settingsHandler);
                   ServiceHandler.displayToast("Database Deleted! \n An app restart is required!");
                   //Get.snackbar("Cache cleared!","Restart may be required!",snackPosition: SnackPosition.TOP,duration: Duration(seconds: 5),colorText: Colors.black, backgroundColor: Get.context!.theme.primaryColor);
                 },
-                child: Text("Delete Database"),
+                child: Text("Delete Database", style: TextStyle(color: Colors.white)),
               ),
             ),
             Container(
               alignment: Alignment.centerLeft,
               margin: EdgeInsets.fromLTRB(20,10,20,10),
-              child: FlatButton(
-                shape: RoundedRectangleBorder(
-                  borderRadius: new BorderRadius.circular(20),
-                  side: BorderSide(color: Get.context!.theme.accentColor),
+              child: TextButton(
+                style: TextButton.styleFrom(
+                  shape: RoundedRectangleBorder(
+                    borderRadius: new BorderRadius.circular(20),
+                    side: BorderSide(color: Get.context!.theme.accentColor),
+                  ),
                 ),
                 onPressed: (){
                   if (widget.settingsHandler.dbHandler.db != null){
@@ -329,16 +379,18 @@ class _SettingsPageState extends State<SettingsPage> {
                     ServiceHandler.displayToast("Snatched Cleared! \n An app restart may be required!");
                   }
                 },
-                child: Text("Clear Snatched"),
+                child: Text("Clear Snatched", style: TextStyle(color: Colors.white)),
               ),
             ),
             Container(
               alignment: Alignment.centerLeft,
               margin: EdgeInsets.fromLTRB(20,10,20,10),
-              child: FlatButton(
-                shape: RoundedRectangleBorder(
-                  borderRadius: new BorderRadius.circular(20),
-                  side: BorderSide(color: Get.context!.theme.accentColor),
+              child: TextButton(
+                style: TextButton.styleFrom(
+                  shape: RoundedRectangleBorder(
+                    borderRadius: new BorderRadius.circular(20),
+                    side: BorderSide(color: Get.context!.theme.accentColor),
+                  ),
                 ),
                 onPressed: (){
                   if (widget.settingsHandler.dbHandler.db != null){
@@ -346,7 +398,7 @@ class _SettingsPageState extends State<SettingsPage> {
                     ServiceHandler.displayToast("Favourites Cleared! \n An app restart may be required!");
                   }
                 },
-                child: Text("Clear Favourites"),
+                child: Text("Clear Favourites", style: TextStyle(color: Colors.white)),
               ),
             ),
             Container(
@@ -412,7 +464,7 @@ class _SettingsPageState extends State<SettingsPage> {
               child: Row(
                 mainAxisSize: MainAxisSize.max,
                 children: <Widget>[
-                  Text("Preview Mode :     "),
+                  Text("Preview Quality :     "),
                   DropdownButton<String>(
                     value: previewMode,
                     icon: Icon(Icons.arrow_downward),
@@ -432,12 +484,13 @@ class _SettingsPageState extends State<SettingsPage> {
                     icon: Icon(Icons.info, color: Get.context!.theme.accentColor),
                     onPressed: () {
                       Get.dialog(
-                          InfoDialog("Preview Mode",
+                          InfoDialog("Preview Quality",
                               [
-                                Text("The preview mode changes the resolution of images in the preview grid"),
+                                Text("The preview quality changes the resolution of images in the preview grid"),
                                 Text(" - Sample - Medium resolution"),
                                 Text(" - Thumbnail - Low resolution"),
-                              ]
+                              ],
+                              CrossAxisAlignment.start,
                           )
                       );
                     },
@@ -452,7 +505,7 @@ class _SettingsPageState extends State<SettingsPage> {
               child: Row(
                 mainAxisSize: MainAxisSize.max,
                 children: <Widget>[
-                  Text("Gallery Mode :     "),
+                  Text("Gallery Quality :     "),
                   DropdownButton<String>(
                     value: galleryMode,
                     icon: Icon(Icons.arrow_downward),
@@ -472,12 +525,13 @@ class _SettingsPageState extends State<SettingsPage> {
                     icon: Icon(Icons.info, color: Get.context!.theme.accentColor),
                     onPressed: () {
                       Get.dialog(
-                          InfoDialog("Gallery Mode",
+                          InfoDialog("Gallery Quality",
                               [
-                                Text("The gallery mode changes the resolution of images in the gallery viewer"),
+                                Text("The gallery quality changes the resolution of images in the gallery viewer"),
                                 Text(" - Sample - Medium resolution"),
                                 Text(" - Full Res - Full resolution"),
-                              ]
+                              ],
+                              CrossAxisAlignment.start,
                           )
                       );
                     },
@@ -547,8 +601,10 @@ class _SettingsPageState extends State<SettingsPage> {
                                 Text("- Stream - Don't cache, start playing as soon as possible"),
                                 Text("- Cache - Saves to device storage, plays only when download is complete"),
                                 Text("- Stream+Cache - Mix of both, but currently leads to double download"),
+                                const SizedBox(height: 10),
                                 Text("[Note]: Videos will cache only if Media Cache is enabled")
-                              ]
+                              ],
+                              CrossAxisAlignment.start,
                           )
                         );
                     },
@@ -560,17 +616,19 @@ class _SettingsPageState extends State<SettingsPage> {
             Container(
               alignment: Alignment.centerLeft,
               margin: EdgeInsets.fromLTRB(20,10,20,10),
-              child: FlatButton(
-                shape: RoundedRectangleBorder(
-                  borderRadius: new BorderRadius.circular(20),
-                  side: BorderSide(color: Get.context!.theme.accentColor),
+              child: TextButton(
+                style: TextButton.styleFrom(
+                  shape: RoundedRectangleBorder(
+                    borderRadius: new BorderRadius.circular(20),
+                    side: BorderSide(color: Get.context!.theme.accentColor),
+                  ),
                 ),
                 onPressed: (){
                   serviceHandler.emptyCache();
                   ServiceHandler.displayToast("Cache cleared! \n Restart may be required!");
                   //Get.snackbar("Cache cleared!","Restart may be required!",snackPosition: SnackPosition.TOP,duration: Duration(seconds: 5),colorText: Colors.black, backgroundColor: Get.context!.theme.primaryColor);
                 },
-                child: Text("Clear cache"),
+                child: Text("Clear cache", style: TextStyle(color: Colors.white)),
               ),
             ),
             Container(
@@ -610,9 +668,10 @@ class _SettingsPageState extends State<SettingsPage> {
                       Get.dialog(
                           InfoDialog("Booru",
                               [
-                                Text("The booru selected here when saving will be set as default"),
+                                Text("The booru selected here will be set as default after saving"),
                                 Text("The default booru will be first to appear in the dropdown boxes"),
-                              ]
+                              ],
+                              CrossAxisAlignment.start,
                           )
                       );
                     },
@@ -627,10 +686,12 @@ class _SettingsPageState extends State<SettingsPage> {
                 children: <Widget>[
                   Container(
                     margin: EdgeInsets.fromLTRB(10,10,10,10),
-                    child: FlatButton(                     // This button loads the booru editor page
-                      shape: RoundedRectangleBorder(
-                        borderRadius: new BorderRadius.circular(20),
-                        side: BorderSide(color: Get.context!.theme.accentColor),
+                    child: TextButton(
+                      style: TextButton.styleFrom(
+                        shape: RoundedRectangleBorder(
+                          borderRadius: new BorderRadius.circular(20),
+                          side: BorderSide(color: Get.context!.theme.accentColor),
+                        ),
                       ),
                       onPressed: (){
                         if(selectedBooru != null){
@@ -638,30 +699,34 @@ class _SettingsPageState extends State<SettingsPage> {
                         }
                         //get to booru edit page;
                       },
-                      child: Text("Edit"),
+                      child: Text("Edit", style: TextStyle(color: Colors.white)),
                     ),
                   ),
                   Container(
                     margin: EdgeInsets.fromLTRB(10,10,10,10),
-                    child: FlatButton(
-                      shape: RoundedRectangleBorder(
-                        borderRadius: new BorderRadius.circular(20),
-                        side: BorderSide(color: Get.context!.theme.accentColor),
+                    child: TextButton(
+                      style: TextButton.styleFrom(
+                        shape: RoundedRectangleBorder(
+                          borderRadius: new BorderRadius.circular(20),
+                          side: BorderSide(color: Get.context!.theme.accentColor),
+                        ),
                       ),
                       onPressed: (){
                         // Open the booru edtor page but with default values
                         Get.to(booruEdit(new Booru("New","","","",""),widget.settingsHandler));
                         //get to booru edit page;
                       },
-                      child: Text("Add new"),
+                      child: Text("Add new", style: TextStyle(color: Colors.white)),
                     ),
                   ),
                   Container(
                     margin: EdgeInsets.fromLTRB(10,10,10,10),
-                    child: FlatButton(
-                      shape: RoundedRectangleBorder(
-                        borderRadius: new BorderRadius.circular(20),
-                        side: BorderSide(color: Get.context!.theme.accentColor),
+                    child: TextButton(
+                      style: TextButton.styleFrom(
+                        shape: RoundedRectangleBorder(
+                          borderRadius: new BorderRadius.circular(20),
+                          side: BorderSide(color: Get.context!.theme.accentColor),
+                        ),
                       ),
                       onPressed: (){
                         // Open the booru edtor page but with default values
@@ -673,7 +738,7 @@ class _SettingsPageState extends State<SettingsPage> {
                         }
                         //get to booru edit page;
                       },
-                      child: Text("Delete"),
+                      child: Text("Delete", style: TextStyle(color: Colors.white)),
                     ),
                   ),
                 ],
@@ -681,28 +746,32 @@ class _SettingsPageState extends State<SettingsPage> {
             ),
             Container(
               alignment: Alignment.center,
-              child: FlatButton(
-                shape: RoundedRectangleBorder(
-                  borderRadius: new BorderRadius.circular(20),
-                  side: BorderSide(color: Get.context!.theme.accentColor),
+              child: TextButton(
+                style: TextButton.styleFrom(
+                  shape: RoundedRectangleBorder(
+                    borderRadius: new BorderRadius.circular(20),
+                    side: BorderSide(color: Get.context!.theme.accentColor),
+                  ),
                 ),
                 onPressed: (){
                   if (selectedBooru == null && widget.settingsHandler.booruList!.isNotEmpty){selectedBooru = widget.settingsHandler.booruList!.elementAt(0);}
-                  widget.settingsHandler.saveSettings(settingsTagsController.text,settingsLimitController.text, previewMode!,settingsColumnsPortraitController.text,settingsColumnsLandscapeController.text,settingsPreloadController.text,jsonWrite,selectedBooru!.name!, autoPlay, loadingGif, imageCache, mediaCache, videoCacheMode!, autoHideImageBar,settingsSnatchCooldownController.text,previewDisplay!, galleryMode!, dbEnabled);
+                  widget.settingsHandler.saveSettings(settingsTagsController.text,settingsLimitController.text, previewMode!,settingsColumnsPortraitController.text,settingsColumnsLandscapeController.text,settingsPreloadController.text,jsonWrite,selectedBooru!.name!, autoPlay, loadingGif, imageCache, mediaCache, videoCacheMode!, autoHideImageBar,settingsSnatchCooldownController.text,previewDisplay!, galleryMode!, dbEnabled, shareAction!);
                 },
-                child: Text("Save"),
+                child: Text("Save settings", style: TextStyle(color: Colors.white)),
               ),
             ),
            /* Container(
               alignment: Alignment.center,
-              child: FlatButton(
-                shape: RoundedRectangleBorder(
-                  borderRadius: new BorderRadius.circular(20),
-                  side: BorderSide(color: Get.context!.theme.accentColor),
+              child: TextButton(
+                style: TextButton.styleFrom(
+                  shape: RoundedRectangleBorder(
+                    borderRadius: new BorderRadius.circular(20),
+                    side: BorderSide(color: Get.context!.theme.accentColor),
+                  ),
                 ),
                 onPressed: (){
                 },
-                child: Text("Save Location"),
+                child: Text("Save Location", style: TextStyle(color: Colors.white)),
               ),
             ),*/
           ],
@@ -715,7 +784,7 @@ class _SettingsPageState extends State<SettingsPage> {
    * This is the same as the drop down used in the Home widget. The reason the code is reused instead of having a global widget is that
    * it cant update the state of the parent widget if it is outside of the class.
    */
-  Future BooruSelector() async{
+  Future BooruSelector() async {
     if(widget.settingsHandler.booruList!.isEmpty){
       await widget.settingsHandler.getBooru();
     }
@@ -737,8 +806,17 @@ class _SettingsPageState extends State<SettingsPage> {
             value: value,
             child: Row(
               children: <Widget>[
-                Text(value.name!),
-                Image.network(value.faviconURL!, width: 16),
+                (value.type == "Favourites"
+                  ? Icon(Icons.favorite, color: Colors.red, size: 18)
+                  : Image.network(
+                      value.faviconURL!,
+                      width: 16,
+                      errorBuilder: (_, __, ___) {
+                        return Icon(Icons.broken_image, size: 18);
+                      }
+                    )
+                ),
+                Text(" ${value.name!}"),
               ],
             ),
           );
@@ -796,10 +874,12 @@ class _booruEditState extends State<booruEdit> {
               alignment: Alignment.center,
               child: Row(
                 children: <Widget>[
-                  FlatButton(
-                    shape: RoundedRectangleBorder(
-                      borderRadius: new BorderRadius.circular(20),
-                      side: BorderSide(color: Get.context!.theme.accentColor),
+                  TextButton(
+                    style: TextButton.styleFrom(
+                      shape: RoundedRectangleBorder(
+                        borderRadius: new BorderRadius.circular(20),
+                        side: BorderSide(color: Get.context!.theme.accentColor),
+                      ),
                     ),
                     onPressed: () async{
                       //Call the booru test
@@ -834,7 +914,7 @@ class _booruEditState extends State<booruEdit> {
                         //Get.snackbar("No Data Returned","Booru Information may be incorrect or the booru doesn't allow api access ",snackPosition: SnackPosition.TOP,duration: Duration(seconds: 5),colorText: Colors.black, backgroundColor: Get.context!.theme.primaryColor);
                       }
                     },
-                    child: Text("Test"),
+                    child: Text("Test", style: TextStyle(color: Colors.white)),
                   ),
                   saveButton(),
                 ],
@@ -985,10 +1065,12 @@ class _booruEditState extends State<booruEdit> {
                 ? [
                   Container(
                     width: double.infinity,
-                    child: FlatButton(
-                      shape: RoundedRectangleBorder(
-                        borderRadius: new BorderRadius.circular(20),
-                        side: BorderSide(color: Get.context!.theme.accentColor),
+                    child: TextButton(
+                      style: TextButton.styleFrom(
+                        shape: RoundedRectangleBorder(
+                          borderRadius: new BorderRadius.circular(20),
+                          side: BorderSide(color: Get.context!.theme.accentColor),
+                        ),
                       ),
                       onPressed: () async{
                         if (selectedBooruType == "Hydrus"){
@@ -1007,7 +1089,7 @@ class _booruEditState extends State<booruEdit> {
                           //Get.snackbar("Hydrus Only","This button only works for Hydrus",snackPosition: SnackPosition.TOP,duration: Duration(seconds: 5),colorText: Colors.black, backgroundColor: Get.context!.theme.primaryColor);
                         }
                       },
-                      child: Text("Get Hydrus Api Key"),
+                      child: Text("Get Hydrus Api Key", style: TextStyle(color: Colors.white)),
                     ),
                   ),
                   Container(
@@ -1085,10 +1167,12 @@ class _booruEditState extends State<booruEdit> {
     if (widget.booruType == ""){
       return Container();
     } else {
-      return FlatButton(
-        shape: RoundedRectangleBorder(
-          borderRadius: new BorderRadius.circular(20),
-          side: BorderSide(color: Get.context!.theme.accentColor),
+      return TextButton(
+        style: TextButton.styleFrom(
+          shape: RoundedRectangleBorder(
+            borderRadius: new BorderRadius.circular(20),
+            side: BorderSide(color: Get.context!.theme.accentColor),
+          ),
         ),
         onPressed:() async{
           getPerms();
@@ -1118,7 +1202,7 @@ class _booruEditState extends State<booruEdit> {
           }
 
         },
-        child: Text("Save"),
+        child: Text("Save", style: TextStyle(color: Colors.white)),
       );
     }
   }

--- a/lib/SnatchHandler.dart
+++ b/lib/SnatchHandler.dart
@@ -1,23 +1,17 @@
 //import 'dart:html';
-import 'package:LoliSnatcher/ServiceHandler.dart';
-import 'package:LoliSnatcher/libBooru/BooruHandlerFactory.dart';
 import 'package:flutter/material.dart';
-import 'libBooru/BooruItem.dart';
-import 'libBooru/GelbooruHandler.dart';
-import 'libBooru/MoebooruHandler.dart';
-import 'libBooru/PhilomenaHandler.dart';
-import 'libBooru/DanbooruHandler.dart';
-import 'libBooru/ShimmieHandler.dart';
-import 'libBooru/BooruHandler.dart';
-import 'libBooru/e621Handler.dart';
-import 'libBooru/Booru.dart';
-import 'ImageWriter.dart';
-import 'package:get/get.dart';
-import 'package:flutter/services.dart';
-import 'getPerms.dart';
-import 'package:LoliSnatcher/SettingsHandler.dart';
 
-class SnatchHandler  {
+import 'package:LoliSnatcher/ImageWriter.dart';
+import 'package:LoliSnatcher/SettingsHandler.dart';
+import 'package:LoliSnatcher/ServiceHandler.dart';
+
+import 'package:LoliSnatcher/libBooru/BooruHandlerFactory.dart';
+import 'package:LoliSnatcher/libBooru/BooruItem.dart';
+import 'package:LoliSnatcher/libBooru/BooruHandler.dart';
+import 'package:LoliSnatcher/libBooru/Booru.dart';
+
+
+class SnatchHandler {
   ValueNotifier? snatchActive = ValueNotifier(false);
   ValueNotifier? snatchStatus = ValueNotifier("");
   ValueNotifier? queuedItems = ValueNotifier(0);

--- a/lib/Snatcher.dart
+++ b/lib/Snatcher.dart
@@ -1,21 +1,12 @@
 //import 'dart:html';
-import 'package:LoliSnatcher/SnatchHandler.dart';
-import 'package:LoliSnatcher/libBooru/BooruHandlerFactory.dart';
-import 'package:flutter/material.dart';
-import 'libBooru/BooruItem.dart';
-import 'libBooru/GelbooruHandler.dart';
-import 'libBooru/MoebooruHandler.dart';
-import 'libBooru/PhilomenaHandler.dart';
-import 'libBooru/DanbooruHandler.dart';
-import 'libBooru/ShimmieHandler.dart';
-import 'libBooru/BooruHandler.dart';
-import 'libBooru/e621Handler.dart';
-import 'libBooru/Booru.dart';
-import 'ImageWriter.dart';
 import 'package:get/get.dart';
 import 'package:flutter/services.dart';
-import 'getPerms.dart';
+import 'package:flutter/material.dart';
+
+import 'package:LoliSnatcher/getPerms.dart';
+import 'package:LoliSnatcher/SnatchHandler.dart';
 import 'package:LoliSnatcher/SettingsHandler.dart';
+import 'package:LoliSnatcher/libBooru/Booru.dart';
 
 
 /**
@@ -94,7 +85,7 @@ class _SnatcherPageState extends State<SnatcherPage> {
                         controller: snatcherAmountController,
                         keyboardType: TextInputType.number,
                         inputFormatters: <TextInputFormatter>[
-                          WhitelistingTextInputFormatter.digitsOnly
+                          FilteringTextInputFormatter.digitsOnly
                         ],
                         decoration: InputDecoration(
                           hintText:"Amount of Images to Snatch",
@@ -124,7 +115,7 @@ class _SnatcherPageState extends State<SnatcherPage> {
                         controller: snatcherSleepController,
                         keyboardType: TextInputType.number,
                         inputFormatters: <TextInputFormatter>[
-                          WhitelistingTextInputFormatter.digitsOnly
+                          FilteringTextInputFormatter.digitsOnly
                         ],
                         decoration: InputDecoration(
                           hintText:"Timeout between snatching (MS)",
@@ -160,10 +151,12 @@ class _SnatcherPageState extends State<SnatcherPage> {
             ),
             Container(
               alignment: Alignment.center,
-              child: FlatButton(
-                shape: RoundedRectangleBorder(
-                  borderRadius: new BorderRadius.circular(20),
-                  side: BorderSide(color: Get.context!.theme.accentColor),
+              child: TextButton(
+                style: TextButton.styleFrom(
+                    shape: RoundedRectangleBorder(
+                      borderRadius: new BorderRadius.circular(20),
+                      side: BorderSide(color: Get.context!.theme.accentColor),
+                    ),
                 ),
                 /**
                  * When the snatch button is pressed the snatch function is called and then
@@ -177,7 +170,7 @@ class _SnatcherPageState extends State<SnatcherPage> {
                   Get.back();
                   //Get.off(SnatcherProgressPage(snatcherTagsController.text,snatcherAmountController.text,snatcherTimeoutController.text));
                 },
-                child: Text("Snatch Images"),
+                child: Text("Snatch Images", style: TextStyle(color: Colors.white)),
               ),
             ),
           ],
@@ -211,9 +204,9 @@ class _SnatcherPageState extends State<SnatcherPage> {
             child: Row(
               children: <Widget>[
                 //Booru Icon
-                value.type == "Favourites" ?
-                Icon(Icons.favorite,color: Colors.red, size: 18) :
-                Image.network(
+                value.type == "Favourites"
+                ? Icon(Icons.favorite,color: Colors.red, size: 18)
+                : Image.network(
                   value.faviconURL!,
                   width: 16,
                   errorBuilder: (_, __, ___) {

--- a/lib/Tools.dart
+++ b/lib/Tools.dart
@@ -1,11 +1,4 @@
 import 'dart:math';
-import 'package:LoliSnatcher/widgets/CachedThumb.dart';
-import 'package:flutter/cupertino.dart';
-import 'package:flutter/material.dart';
-import 'package:get/get.dart';
-
-import 'SettingsHandler.dart';
-import 'libBooru/BooruItem.dart';
 
 class Tools {
   // code taken from: https://gist.github.com/zzpmaster/ec51afdbbfa5b2bf6ced13374ff891d9

--- a/lib/ViewUtils.dart
+++ b/lib/ViewUtils.dart
@@ -1,12 +1,12 @@
 
 import 'dart:math';
-import 'package:LoliSnatcher/SearchGlobals.dart';
-import 'package:LoliSnatcher/widgets/CachedThumb.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
-import 'SettingsHandler.dart';
-import 'libBooru/BooruItem.dart';
+import 'package:LoliSnatcher/SettingsHandler.dart';
+import 'package:LoliSnatcher/libBooru/BooruItem.dart';
+import 'package:LoliSnatcher/SearchGlobals.dart';
+import 'package:LoliSnatcher/widgets/CachedThumb.dart';
 
 class ViewUtils {
 
@@ -21,6 +21,7 @@ class ViewUtils {
       return ['other', CupertinoIcons.question];
     }
   }
+
   /* This will return an Image from the booruItem and will use either the sample url
   * or the thumbnail url depending on the users settings (sampleURL is much higher quality)
   *
@@ -66,15 +67,14 @@ class ViewUtils {
       ),
     ]);
   }
+
   static void jumpToItem(int item, SearchGlobals searchGlobals, ScrollController gridController, SettingsHandler settingsHandler, BuildContext context) {
     int? totalItems = searchGlobals.booruHandler!.fetched!.length;
     print("jump to item called index is: $item");
     if (totalItems > 0) {
       double viewportHeight = gridController.position.viewportDimension;
-      double totalHeight =
-          gridController.position.maxScrollExtent + viewportHeight;
-      int columnsCount =
-      (MediaQuery.of(context).orientation == Orientation.portrait)
+      double totalHeight = gridController.position.maxScrollExtent + viewportHeight;
+      int columnsCount = (MediaQuery.of(context).orientation == Orientation.portrait)
           ? settingsHandler.portraitColumns
           : settingsHandler.landscapeColumns;
       int rowCount = (totalItems / columnsCount).ceil();
@@ -93,7 +93,12 @@ class ViewUtils {
       // print(newValue);
 
       //gridController.jumpTo(scrollToValue);
-      gridController.animateTo(scrollToValue, duration: Duration(milliseconds: 300), curve: Curves.linear);
+      // gridController.animateTo(scrollToValue, duration: Duration(milliseconds: 300), curve: Curves.linear);
+      WidgetsBinding.instance!.addPostFrameCallback((_) {
+        if(gridController.hasClients){
+          gridController.animateTo(scrollToValue, duration: Duration(milliseconds: 300), curve: Curves.linear);
+        }
+      });
     }
   }
 }

--- a/lib/libBooru/Booru.dart
+++ b/lib/libBooru/Booru.dart
@@ -1,7 +1,5 @@
 import 'dart:io';
 
-import 'package:flutter/material.dart';
-
 class Booru {
   String? name,faviconURL,type,baseURL,apiKey = "",userID = "",defTags;
   Booru(this.name,this.type,this.faviconURL,this.baseURL,this.defTags);

--- a/lib/libBooru/BooruOnRailsHandler.dart
+++ b/lib/libBooru/BooruOnRailsHandler.dart
@@ -91,7 +91,7 @@ class BooruOnRailsHandler extends BooruHandler {
       if (response.statusCode == 200) {
         List<dynamic> parsedResponse = jsonDecode(response.body);
         if (parsedResponse.length > 0){
-          for (int i=0; i < 5; i++){
+          for (int i=0; i < 10; i++) {
             searchTags.add(parsedResponse[i]['slug'].toString());
           }
         }

--- a/lib/libBooru/DanbooruHandler.dart
+++ b/lib/libBooru/DanbooruHandler.dart
@@ -92,7 +92,7 @@ class DanbooruHandler extends BooruHandler{
 
   }
   String makeTagURL(String input){
-    return "${booru.baseURL}/tags.json?search[name_matches]=$input*&limit=5";
+    return "${booru.baseURL}/tags.json?search[name_matches]=$input*&limit=10";
   }
   @override
   Future tagSearch(String input) async {

--- a/lib/libBooru/GelbooruHandler.dart
+++ b/lib/libBooru/GelbooruHandler.dart
@@ -84,7 +84,7 @@ class GelbooruHandler extends BooruHandler{
       if (booru.baseURL!.contains("rule34.xxx")){
         return "${booru.baseURL}/autocomplete.php?q=$input"; // doesn't allow limit, but sorts by popularity
       } else {
-        return "${booru.baseURL}/index.php?page=dapi&s=tag&q=index&name_pattern=$input%&limit=5";
+        return "${booru.baseURL}/index.php?page=dapi&s=tag&q=index&name_pattern=$input%&limit=10";
       }
     }
     @override

--- a/lib/libBooru/GelbooruV1Handler.dart
+++ b/lib/libBooru/GelbooruV1Handler.dart
@@ -1,10 +1,5 @@
-import 'dart:convert';
-
-import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
-import 'package:xml/xml.dart' as xml;
 import 'package:html/parser.dart';
-import 'package:html/dom.dart';
 import 'dart:async';
 import 'BooruHandler.dart';
 import 'BooruItem.dart';

--- a/lib/libBooru/HydrusHandler.dart
+++ b/lib/libBooru/HydrusHandler.dart
@@ -155,7 +155,7 @@ class HydrusHandler extends BooruHandler{
       return "${booru.baseURL}/get_files/search_files?tags=$tag";
     }
     String makeTagURL(String input){
-      return "${booru.baseURL}/index.php?page=dapi&s=tag&q=index&name_pattern=$input%&limit=5";
+      return "${booru.baseURL}/index.php?page=dapi&s=tag&q=index&name_pattern=$input%&limit=10";
     }
 
 }

--- a/lib/libBooru/MoebooruHandler.dart
+++ b/lib/libBooru/MoebooruHandler.dart
@@ -21,7 +21,7 @@ class MoebooruHandler extends GelbooruHandler{
   }
   @override
   String makeTagURL(String input){
-      return "${booru.baseURL}/tag.xml?limit=5&name=$input*";
+      return "${booru.baseURL}/tag.xml?limit=10&name=$input*";
   }
 
 }

--- a/lib/libBooru/PhilomenaHandler.dart
+++ b/lib/libBooru/PhilomenaHandler.dart
@@ -72,7 +72,7 @@ class PhilomenaHandler extends BooruHandler{
   }
 
   String makeTagURL(String input){
-    return "${booru.baseURL}/api/v1/json/search/tags?q=$input&per_page=5";
+    return "${booru.baseURL}/api/v1/json/search/tags?q=$input&per_page=10";
   }
   @override
   Future tagSearch(String input) async {

--- a/lib/libBooru/SankakuHandler.dart
+++ b/lib/libBooru/SankakuHandler.dart
@@ -119,7 +119,7 @@ class SankakuHandler extends BooruHandler{
   }
 
   String makeTagURL(String input){
-    return "${booru.baseURL}/tags?name=$input&limit=5";
+    return "${booru.baseURL}/tags?name=${input.toLowerCase()}&limit=10";
   }
   @override
   Future tagSearch(String input) async {

--- a/lib/libBooru/ShimmieHandler.dart
+++ b/lib/libBooru/ShimmieHandler.dart
@@ -93,7 +93,7 @@ class ShimmieHandler extends BooruHandler{
     if (booru.baseURL!.contains("rule34.paheal.net")){
       return "${booru.baseURL}/api/internal/autocomplete?s=$input"; // doesn't allow limit, but sorts by popularity
     } else {
-      return "${booru.baseURL}/tags.json?search[name_matches]=$input*&limit=5";
+      return "${booru.baseURL}/tags.json?search[name_matches]=$input*&limit=10";
     }
   }
   //No api documentation on finding tags

--- a/lib/libBooru/SzurubooruHandler.dart
+++ b/lib/libBooru/SzurubooruHandler.dart
@@ -87,7 +87,7 @@ class SzurubooruHandler extends BooruHandler{
     }
 
   String makeTagURL(String input){
-    return "${booru.baseURL}/api/tags/?offset=0&limit=5&query=$input*";
+    return "${booru.baseURL}/api/tags/?offset=0&limit=10&query=$input*";
   }
   @override
   Future tagSearch(String input) async {

--- a/lib/libBooru/e621Handler.dart
+++ b/lib/libBooru/e621Handler.dart
@@ -79,7 +79,7 @@ class e621Handler extends BooruHandler{
     }
   }
   String makeTagURL(String input){
-    return "${booru.baseURL}/tags.json?search[name_matches]=$input*&limit=5";
+    return "${booru.baseURL}/tags.json?search[name_matches]=$input*&limit=10";
   }
   @override
   Future tagSearch(String input) async {

--- a/lib/widgets/CachedThumb.dart
+++ b/lib/widgets/CachedThumb.dart
@@ -1,10 +1,14 @@
 import 'dart:io';
 import 'dart:ui';
 import 'dart:async';
+import 'dart:typed_data';
+
 import 'package:get/get.dart';
 import 'package:http/http.dart';
+import 'package:http/io_client.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/cupertino.dart';
+
 import 'package:LoliSnatcher/ImageWriter.dart';
 import 'package:LoliSnatcher/SettingsHandler.dart';
 
@@ -20,84 +24,96 @@ class CachedThumb extends StatefulWidget {
 class _CachedThumbState extends State<CachedThumb> {
   final ImageWriter imageWriter = ImageWriter();
   int _total = 0, _received = 0;
-  bool isFromCache = false;
+  bool? isFromCache;
+  IOClient? _client;
   StreamedResponse? _response;
-  File? _image;
-  List<int> _bytes = [];
   StreamSubscription? _subscription;
+  List<int> _bytes = [];
+  Uint8List _totalBytes = Uint8List(0);
 
+  /// Author: [Nani-Sore] ///
   Future<void> _downloadImage() async {
-    final String filePath =
-        await imageWriter.getCachePath(widget.thumbURL, 'thumbnails');
+    final String? filePath = await imageWriter.getCachePath(widget.thumbURL, 'thumbnails');
 
     // If file is in cache - load
     if (filePath != null) {
       final File file = File(filePath);
-      await file.readAsBytes();
       setState(() {
-        _image = file;
+        // multiple restates in the same function is usually bad practice, but we need this to notify user how the file is loaded while we await for bytes
         isFromCache = true;
+      });
+      Uint8List tempBytes = await file.readAsBytes();
+      setState(() {
+        _totalBytes = tempBytes;
       });
       return;
     }
 
     // Otherwise start loading and subscribe to progress
-    _response = await Client().send(Request('GET', Uri.parse(widget.thumbURL)));
+    _client = IOClient();
+    _response = await _client!.send(Request('GET', Uri.parse(widget.thumbURL)));
     _total = _response!.contentLength!;
 
-    _subscription = _response!.stream.listen((value) {
-      setState(() {
-        _bytes.addAll(value);
-        _received += value.length;
-      });
+    setState(() {
+      isFromCache = false;
     });
-    _subscription!.onDone(() async {
-      if (_received > (_total * 0.95)) {
-        // Sometimes stream ends before fully loading, so we require at least 95% loaded to write to cache
-        final File cacheFile = await imageWriter.writeCacheFromBytes(
-            widget.thumbURL, _bytes, 'thumbnails');
-        if (cacheFile != null) {
-          setState(() {
-            _image = cacheFile;
+
+    _subscription = _response!.stream.listen(
+      (value) {
+        setState(() {
+          _bytes.addAll(value);
+          _received += value.length;
+        });
+      },
+      onError: (e) {
+        print(e);
+      },
+      cancelOnError: true,
+      onDone: () async {
+        if (_received > (_total * 0.95)) {
+          // Sometimes stream ends before fully loading, so we require at least 95% loaded to write to cache
+          setState((){
+            _totalBytes = Uint8List.fromList(_bytes);
           });
+          if (widget.settingsHandler.imageCache) {
+            await imageWriter.writeCacheFromBytes(widget.thumbURL, _bytes, 'thumbnails');
+          }
+        } else {
+          print('Thumbnail load incomplete');
         }
-      } else {
-        print('Thumbnail load incomplete'); // Throw an error, allow to retry?
       }
-    });
+    );
   }
 
   @override
   void initState() {
     super.initState();
 
-    if (widget.settingsHandler.imageCache) {
-      _downloadImage();
-    }
+    _downloadImage();
   }
 
   @override
   void dispose() {
     super.dispose();
     _subscription?.cancel();
+    _client?.close();
   }
 
-  Widget loadingElementBuilder(
-      BuildContext ctx, Widget child, ImageChunkEvent loadingProgress) {
-    if (loadingProgress == null && !widget.settingsHandler.imageCache) {
-      // Resulting image for network loaded thumbnail
-      return child;
-    }
-    bool hasProgressData = (loadingProgress != null && loadingProgress.expectedTotalBytes != null) || (widget.settingsHandler.imageCache && _total != null && _total > 0);
-    bool isProgressFromCaching = widget.settingsHandler.imageCache && hasProgressData && _total != null && _total > 0;
-    int expectedBytes = (hasProgressData ? (isProgressFromCaching ? _received : loadingProgress.cumulativeBytesLoaded) : null)!;
-    int totalBytes = (hasProgressData ? (isProgressFromCaching ? _total : loadingProgress.expectedTotalBytes) : null)!;
+  Widget loadingElementBuilder(BuildContext ctx, Widget child, ImageChunkEvent? loadingProgress) {
+    // if (loadingProgress == null && !widget.settingsHandler.imageCache) {
+    //   // Resulting image for network loaded thumbnail
+    //   return child;
+    // }
+    bool hasProgressData = (loadingProgress != null && loadingProgress.expectedTotalBytes != null) || (_total > 0);
+    bool isProgressFromCaching = hasProgressData && _total > 0;
+    int? expectedBytes = (hasProgressData ? (isProgressFromCaching ? _received : loadingProgress!.cumulativeBytesLoaded) : null);
+    int? totalBytes = (hasProgressData ? (isProgressFromCaching ? _total : loadingProgress!.expectedTotalBytes) : null);
 
-    double percentDone = (hasProgressData ? expectedBytes / totalBytes : null)!;
-    String percentDoneText = hasProgressData ? ((percentDone * 100).toStringAsFixed(2) + '%') : 'Loading...';
+    double? percentDone = (hasProgressData ? expectedBytes! / totalBytes! : null);
+    String percentDoneText = hasProgressData ? ((percentDone! * 100).toStringAsFixed(2) + '%') : 'Loading...';
     return Column(
       mainAxisAlignment: MainAxisAlignment.center,
-      children: [
+      children: (isFromCache == null || isFromCache == true) ? [] : [
         SizedBox(
           height: 100 / widget.columnCount,
           width: 100 / widget.columnCount,
@@ -122,25 +138,16 @@ class _CachedThumbState extends State<CachedThumb> {
 
   @override
   Widget build(BuildContext context) {
-    // Load from network if caching is disabled
-    if (!widget.settingsHandler.imageCache) {
-      return Image.network(widget.thumbURL,
-          fit: widget.settingsHandler.previewDisplay == "Waterfall" ? BoxFit.cover : BoxFit.contain,
-          width: widget.settingsHandler.previewDisplay == "Waterfall" ? double.infinity : Get.width,
-          height: widget.settingsHandler.previewDisplay == "Waterfall" ? double.infinity : null,
-          );
+    // Show progress until image bytes are fetched (either from network or cache)
+    if (_totalBytes.length == 0) {
+      return loadingElementBuilder(context, Center(child: Text("Error")), null);
     } else {
-      // Show progress until image is saved to/retrieved from cache
-      if (_image == null) {
-        return Center(child: Text("Error"));
-      } else {
-        return Image.file(
-          _image!,
-          fit: widget.settingsHandler.previewDisplay == "Waterfall" ? BoxFit.cover : BoxFit.contain ,
-          width: widget.settingsHandler.previewDisplay == "Waterfall" ? double.infinity : Get.width,
-          height: widget.settingsHandler.previewDisplay == "Waterfall" ? double.infinity : null,
-        );
-      }
+      return Image.memory(
+        _totalBytes,
+        fit: widget.settingsHandler.previewDisplay == "Waterfall" ? BoxFit.cover : BoxFit.contain ,
+        width: widget.settingsHandler.previewDisplay == "Waterfall" ? double.infinity : Get.width,
+        height: widget.settingsHandler.previewDisplay == "Waterfall" ? double.infinity : null,
+      );
     }
   }
 }

--- a/lib/widgets/HideableAppbar.dart
+++ b/lib/widgets/HideableAppbar.dart
@@ -1,10 +1,9 @@
-
 import 'dart:ui';
 import 'package:flutter/material.dart';
 import 'package:flutter/cupertino.dart';
+import 'package:flutter/services.dart';
 
 import 'package:LoliSnatcher/SearchGlobals.dart';
-import 'package:flutter/services.dart';
 
 class HideableAppBar extends StatefulWidget implements PreferredSizeWidget {
   String title;
@@ -13,7 +12,7 @@ class HideableAppBar extends StatefulWidget implements PreferredSizeWidget {
   bool autoHide;
   HideableAppBar(this.title, this.actions, this.searchGlobals, this.autoHide);
 
-  double defaultHeight = kToolbarHeight; //56.0
+  final double defaultHeight = kToolbarHeight; //56.0
   @override
   Size get preferredSize => Size.fromHeight(defaultHeight);
 
@@ -60,7 +59,7 @@ class _HideableAppBarState extends State<HideableAppBar> {
           icon: Icon(Icons.arrow_back, color: Colors.black),
           onPressed: () => Navigator.of(context).pop(),
         ),
-        title: Text(widget.title),
+        title: FittedBox(fit: BoxFit.fitWidth, child: Text(widget.title)),
         actions: widget.actions,
       ),
     );

--- a/lib/widgets/InfoDialog.dart
+++ b/lib/widgets/InfoDialog.dart
@@ -4,9 +4,10 @@ import 'package:flutter/material.dart';
 class InfoDialog extends StatefulWidget {
   String title;
   List<Widget> bodyWidgets;
+  CrossAxisAlignment horizontalAlignment;
   @override
   _InfoDialogState createState() => _InfoDialogState();
-  InfoDialog(this.title,this.bodyWidgets);
+  InfoDialog(this.title,this.bodyWidgets,this.horizontalAlignment);
 }
 
 class _InfoDialogState extends State<InfoDialog> {
@@ -28,6 +29,7 @@ class _InfoDialogState extends State<InfoDialog> {
             Container(
                 margin: EdgeInsets.all(10),
                 child: Column(
+                  crossAxisAlignment: widget.horizontalAlignment,
                   children: widget.bodyWidgets,
                 )
             )

--- a/lib/widgets/PreloadPageView.dart
+++ b/lib/widgets/PreloadPageView.dart
@@ -1,0 +1,945 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:math' as math;
+
+import 'package:flutter/rendering.dart';
+import 'package:flutter/gestures.dart' show DragStartBehavior;
+import 'package:flutter/foundation.dart' show precisionErrorTolerance;
+
+import 'package:flutter/physics.dart';
+import 'package:flutter/widgets.dart';
+
+/// A controller for [PageView].
+///
+/// A page controller lets you manipulate which page is visible in a [PageView].
+/// In addition to being able to control the pixel offset of the content inside
+/// the [PageView], a [PageController] also lets you control the offset in terms
+/// of pages, which are increments of the viewport size.
+///
+/// See also:
+///
+///  * [PageView], which is the widget this object controls.
+///
+/// {@tool snippet}
+///
+/// This widget introduces a [MaterialApp], [Scaffold] and [PageView] with two pages
+/// using the default constructor. Both pages contain an [ElevatedButton] allowing you
+/// to animate the [PageView] using a [PageController].
+///
+/// ```dart
+/// class MyPageView extends StatefulWidget {
+///   MyPageView({Key? key}) : super(key: key);
+///
+///   _MyPageViewState createState() => _MyPageViewState();
+/// }
+///
+/// class _MyPageViewState extends State<MyPageView> {
+///   PageController _pageController = PageController();
+///
+///   @override
+///   void dispose() {
+///     _pageController.dispose();
+///     super.dispose();
+///   }
+///
+///   @override
+///   Widget build(BuildContext context) {
+///     return MaterialApp(
+///       home: Scaffold(
+///         body: PageView(
+///           controller: _pageController,
+///           children: [
+///             Container(
+///               color: Colors.red,
+///               child: Center(
+///                 child: ElevatedButton(
+///                   onPressed: () {
+///                     if (_pageController.hasClients) {
+///                       _pageController.animateToPage(
+///                         1,
+///                         duration: const Duration(milliseconds: 400),
+///                         curve: Curves.easeInOut,
+///                       );
+///                     }
+///                   },
+///                   child: Text('Next'),
+///                 ),
+///               ),
+///             ),
+///             Container(
+///               color: Colors.blue,
+///               child: Center(
+///                 child: ElevatedButton(
+///                   onPressed: () {
+///                     if (_pageController.hasClients) {
+///                       _pageController.animateToPage(
+///                         0,
+///                         duration: const Duration(milliseconds: 400),
+///                         curve: Curves.easeInOut,
+///                       );
+///                     }
+///                   },
+///                   child: Text('Previous'),
+///                 ),
+///               ),
+///             ),
+///           ],
+///         ),
+///       ),
+///     );
+///   }
+/// }
+///
+/// ```
+/// {@end-tool}
+class PageController extends ScrollController {
+  /// Creates a page controller.
+  ///
+  /// The [initialPage], [keepPage], and [viewportFraction] arguments must not be null.
+  PageController({
+    this.initialPage = 0,
+    this.keepPage = true,
+    this.viewportFraction = 1.0,
+  }) : assert(initialPage != null),
+       assert(keepPage != null),
+       assert(viewportFraction != null),
+       assert(viewportFraction > 0.0);
+
+  /// The page to show when first creating the [PageView].
+  final int initialPage;
+
+  /// Save the current [page] with [PageStorage] and restore it if
+  /// this controller's scrollable is recreated.
+  ///
+  /// If this property is set to false, the current [page] is never saved
+  /// and [initialPage] is always used to initialize the scroll offset.
+  /// If true (the default), the initial page is used the first time the
+  /// controller's scrollable is created, since there's isn't a page to
+  /// restore yet. Subsequently the saved page is restored and
+  /// [initialPage] is ignored.
+  ///
+  /// See also:
+  ///
+  ///  * [PageStorageKey], which should be used when more than one
+  ///    scrollable appears in the same route, to distinguish the [PageStorage]
+  ///    locations used to save scroll offsets.
+  final bool keepPage;
+
+  /// The fraction of the viewport that each page should occupy.
+  ///
+  /// Defaults to 1.0, which means each page fills the viewport in the scrolling
+  /// direction.
+  final double viewportFraction;
+
+  /// The current page displayed in the controlled [PageView].
+  ///
+  /// There are circumstances that this [PageController] can't know the current
+  /// page. Reading [page] will throw an [AssertionError] in the following cases:
+  ///
+  /// 1. No [PageView] is currently using this [PageController]. Once a
+  /// [PageView] starts using this [PageController], the new [page]
+  /// position will be derived:
+  ///
+  ///   * First, based on the attached [PageView]'s [BuildContext] and the
+  ///     position saved at that context's [PageStorage] if [keepPage] is true.
+  ///   * Second, from the [PageController]'s [initialPage].
+  ///
+  /// 2. More than one [PageView] using the same [PageController].
+  ///
+  /// The [hasClients] property can be used to check if a [PageView] is attached
+  /// prior to accessing [page].
+  double? get page {
+    assert(
+      positions.isNotEmpty,
+      'PageController.page cannot be accessed before a PageView is built with it.',
+    );
+    assert(
+      positions.length == 1,
+      'The page property cannot be read when multiple PageViews are attached to '
+      'the same PageController.',
+    );
+    final _PagePosition position = this.position as _PagePosition;
+    return position.page;
+  }
+
+  /// Animates the controlled [PageView] from the current page to the given page.
+  ///
+  /// The animation lasts for the given duration and follows the given curve.
+  /// The returned [Future] resolves when the animation completes.
+  ///
+  /// The `duration` and `curve` arguments must not be null.
+  Future<void> animateToPage(
+    int page, {
+    required Duration duration,
+    required Curve curve,
+  }) {
+    final _PagePosition position = this.position as _PagePosition;
+    return position.animateTo(
+      position.getPixelsFromPage(page.toDouble()),
+      duration: duration,
+      curve: curve,
+    );
+  }
+
+  /// Changes which page is displayed in the controlled [PageView].
+  ///
+  /// Jumps the page position from its current value to the given value,
+  /// without animation, and without checking if the new value is in range.
+  void jumpToPage(int page) {
+    final _PagePosition position = this.position as _PagePosition;
+    position.jumpTo(position.getPixelsFromPage(page.toDouble()));
+  }
+
+  /// Animates the controlled [PageView] to the next page.
+  ///
+  /// The animation lasts for the given duration and follows the given curve.
+  /// The returned [Future] resolves when the animation completes.
+  ///
+  /// The `duration` and `curve` arguments must not be null.
+  Future<void> nextPage({ required Duration duration, required Curve curve }) {
+    return animateToPage(page!.round() + 1, duration: duration, curve: curve);
+  }
+
+  /// Animates the controlled [PageView] to the previous page.
+  ///
+  /// The animation lasts for the given duration and follows the given curve.
+  /// The returned [Future] resolves when the animation completes.
+  ///
+  /// The `duration` and `curve` arguments must not be null.
+  Future<void> previousPage({ required Duration duration, required Curve curve }) {
+    return animateToPage(page!.round() - 1, duration: duration, curve: curve);
+  }
+
+  @override
+  ScrollPosition createScrollPosition(ScrollPhysics physics, ScrollContext context, ScrollPosition? oldPosition) {
+    return _PagePosition(
+      physics: physics,
+      context: context,
+      initialPage: initialPage,
+      keepPage: keepPage,
+      viewportFraction: viewportFraction,
+      oldPosition: oldPosition,
+    );
+  }
+
+  @override
+  void attach(ScrollPosition position) {
+    super.attach(position);
+    final _PagePosition pagePosition = position as _PagePosition;
+    pagePosition.viewportFraction = viewportFraction;
+  }
+}
+
+/// Metrics for a [PageView].
+///
+/// The metrics are available on [ScrollNotification]s generated from
+/// [PageView]s.
+class PageMetrics extends FixedScrollMetrics {
+  /// Creates an immutable snapshot of values associated with a [PageView].
+  PageMetrics({
+    required double? minScrollExtent,
+    required double? maxScrollExtent,
+    required double? pixels,
+    required double? viewportDimension,
+    required AxisDirection axisDirection,
+    required this.viewportFraction,
+  }) : super(
+         minScrollExtent: minScrollExtent,
+         maxScrollExtent: maxScrollExtent,
+         pixels: pixels,
+         viewportDimension: viewportDimension,
+         axisDirection: axisDirection,
+       );
+
+  @override
+  PageMetrics copyWith({
+    double? minScrollExtent,
+    double? maxScrollExtent,
+    double? pixels,
+    double? viewportDimension,
+    AxisDirection? axisDirection,
+    double? viewportFraction,
+  }) {
+    return PageMetrics(
+      minScrollExtent: minScrollExtent ?? (hasContentDimensions ? this.minScrollExtent : null),
+      maxScrollExtent: maxScrollExtent ?? (hasContentDimensions ? this.maxScrollExtent : null),
+      pixels: pixels ?? (hasPixels ? this.pixels : null),
+      viewportDimension: viewportDimension ?? (hasViewportDimension ? this.viewportDimension : null),
+      axisDirection: axisDirection ?? this.axisDirection,
+      viewportFraction: viewportFraction ?? this.viewportFraction,
+    );
+  }
+
+  /// The current page displayed in the [PageView].
+  double? get page {
+    return math.max(0.0, pixels.clamp(minScrollExtent, maxScrollExtent)) /
+           math.max(1.0, viewportDimension * viewportFraction);
+  }
+
+  /// The fraction of the viewport that each page occupies.
+  ///
+  /// Used to compute [page] from the current [pixels].
+  final double viewportFraction;
+}
+
+class _PagePosition extends ScrollPositionWithSingleContext implements PageMetrics {
+  _PagePosition({
+    required ScrollPhysics physics,
+    required ScrollContext context,
+    this.initialPage = 0,
+    bool keepPage = true,
+    double viewportFraction = 1.0,
+    ScrollPosition? oldPosition,
+  }) : assert(initialPage != null),
+       assert(keepPage != null),
+       assert(viewportFraction != null),
+       assert(viewportFraction > 0.0),
+       _viewportFraction = viewportFraction,
+       _pageToUseOnStartup = initialPage.toDouble(),
+       super(
+         physics: physics,
+         context: context,
+         initialPixels: null,
+         keepScrollOffset: keepPage,
+         oldPosition: oldPosition,
+       );
+
+  final int initialPage;
+  double _pageToUseOnStartup;
+
+  @override
+  Future<void> ensureVisible(
+    RenderObject object, {
+    double alignment = 0.0,
+    Duration duration = Duration.zero,
+    Curve curve = Curves.ease,
+    ScrollPositionAlignmentPolicy alignmentPolicy = ScrollPositionAlignmentPolicy.explicit,
+    RenderObject? targetRenderObject,
+  }) {
+    // Since the _PagePosition is intended to cover the available space within
+    // its viewport, stop trying to move the target render object to the center
+    // - otherwise, could end up changing which page is visible and moving the
+    // targetRenderObject out of the viewport.
+    return super.ensureVisible(
+      object,
+      alignment: alignment,
+      duration: duration,
+      curve: curve,
+      alignmentPolicy: alignmentPolicy,
+      targetRenderObject: null,
+    );
+  }
+
+  @override
+  double get viewportFraction => _viewportFraction;
+  double _viewportFraction;
+  set viewportFraction(double value) {
+    if (_viewportFraction == value)
+      return;
+    final double? oldPage = page;
+    _viewportFraction = value;
+    if (oldPage != null)
+      forcePixels(getPixelsFromPage(oldPage));
+  }
+
+  // The amount of offset that will be added to [minScrollExtent] and subtracted
+  // from [maxScrollExtent], such that every page will properly snap to the center
+  // of the viewport when viewportFraction is greater than 1.
+  //
+  // The value is 0 if viewportFraction is less than or equal to 1, larger than 0
+  // otherwise.
+  double get _initialPageOffset => math.max(0, viewportDimension * (viewportFraction - 1) / 2);
+
+  double getPageFromPixels(double pixels, double viewportDimension) {
+    final double actual = math.max(0.0, pixels - _initialPageOffset) / math.max(1.0, viewportDimension * viewportFraction);
+    final double round = actual.roundToDouble();
+    if ((actual - round).abs() < precisionErrorTolerance) {
+      return round;
+    }
+    return actual;
+  }
+
+  double getPixelsFromPage(double page) {
+    return page * viewportDimension * viewportFraction + _initialPageOffset;
+  }
+
+  @override
+  double? get page {
+    assert(
+      !hasPixels || (minScrollExtent != null && maxScrollExtent != null),
+      'Page value is only available after content dimensions are established.',
+    );
+    return !hasPixels ? null : getPageFromPixels(pixels.clamp(minScrollExtent, maxScrollExtent), viewportDimension);
+  }
+
+  @override
+  void saveScrollOffset() {
+    PageStorage.of(context.storageContext)?.writeState(context.storageContext, getPageFromPixels(pixels, viewportDimension));
+  }
+
+  @override
+  void restoreScrollOffset() {
+    if (!hasPixels) {
+      final double? value = PageStorage.of(context.storageContext)?.readState(context.storageContext) as double?;
+      if (value != null)
+        _pageToUseOnStartup = value;
+    }
+  }
+
+  @override
+  void saveOffset() {
+    context.saveOffset(getPageFromPixels(pixels, viewportDimension));
+  }
+
+  @override
+  void restoreOffset(double offset, {bool initialRestore = false}) {
+    assert(initialRestore != null);
+    assert(offset != null);
+    if (initialRestore) {
+      _pageToUseOnStartup = offset;
+    } else {
+      jumpTo(getPixelsFromPage(offset));
+    }
+  }
+
+  @override
+  bool applyViewportDimension(double viewportDimension) {
+    final double? oldViewportDimensions = hasViewportDimension ? this.viewportDimension : null;
+    if (viewportDimension == oldViewportDimensions) {
+      return true;
+    }
+    final bool result = super.applyViewportDimension(viewportDimension);
+    final double? oldPixels = hasPixels ? pixels : null;
+    final double page = (oldPixels == null || oldViewportDimensions == 0.0) ? _pageToUseOnStartup : getPageFromPixels(oldPixels, oldViewportDimensions!);
+    final double newPixels = getPixelsFromPage(page);
+
+    if (newPixels != oldPixels) {
+      correctPixels(newPixels);
+      return false;
+    }
+    return result;
+  }
+
+  @override
+  bool applyContentDimensions(double minScrollExtent, double maxScrollExtent) {
+    final double newMinScrollExtent = minScrollExtent + _initialPageOffset;
+    return super.applyContentDimensions(
+      newMinScrollExtent,
+      math.max(newMinScrollExtent, maxScrollExtent - _initialPageOffset),
+    );
+  }
+
+  @override
+  PageMetrics copyWith({
+    double? minScrollExtent,
+    double? maxScrollExtent,
+    double? pixels,
+    double? viewportDimension,
+    AxisDirection? axisDirection,
+    double? viewportFraction,
+  }) {
+    return PageMetrics(
+      minScrollExtent: minScrollExtent ?? (hasContentDimensions ? this.minScrollExtent : null),
+      maxScrollExtent: maxScrollExtent ?? (hasContentDimensions ? this.maxScrollExtent : null),
+      pixels: pixels ?? (hasPixels ? this.pixels : null),
+      viewportDimension: viewportDimension ?? (hasViewportDimension ? this.viewportDimension : null),
+      axisDirection: axisDirection ?? this.axisDirection,
+      viewportFraction: viewportFraction ?? this.viewportFraction,
+    );
+  }
+}
+
+class _ForceImplicitScrollPhysics extends ScrollPhysics {
+  const _ForceImplicitScrollPhysics({
+    required this.allowImplicitScrolling,
+    ScrollPhysics? parent,
+  }) : assert(allowImplicitScrolling != null),
+       super(parent: parent);
+
+  @override
+  _ForceImplicitScrollPhysics applyTo(ScrollPhysics? ancestor) {
+    return _ForceImplicitScrollPhysics(
+      allowImplicitScrolling: allowImplicitScrolling,
+      parent: buildParent(ancestor),
+    );
+  }
+
+  @override
+  final bool allowImplicitScrolling;
+}
+
+/// Scroll physics used by a [PageView].
+///
+/// These physics cause the page view to snap to page boundaries.
+///
+/// See also:
+///
+///  * [ScrollPhysics], the base class which defines the API for scrolling
+///    physics.
+///  * [PageView.physics], which can override the physics used by a page view.
+class PageScrollPhysics extends ScrollPhysics {
+  /// Creates physics for a [PageView].
+  const PageScrollPhysics({ ScrollPhysics? parent }) : super(parent: parent);
+
+  @override
+  PageScrollPhysics applyTo(ScrollPhysics? ancestor) {
+    return PageScrollPhysics(parent: buildParent(ancestor));
+  }
+
+  double _getPage(ScrollMetrics position) {
+    if (position is _PagePosition)
+      return position.page!;
+    return position.pixels / position.viewportDimension;
+  }
+
+  double _getPixels(ScrollMetrics position, double page) {
+    if (position is _PagePosition)
+      return position.getPixelsFromPage(page);
+    return page * position.viewportDimension;
+  }
+
+  double _getTargetPixels(ScrollMetrics position, Tolerance tolerance, double velocity) {
+    double page = _getPage(position);
+    if (velocity < -tolerance.velocity)
+      page -= 0.5;
+    else if (velocity > tolerance.velocity)
+      page += 0.5;
+    return _getPixels(position, page.roundToDouble());
+  }
+
+  @override
+  Simulation? createBallisticSimulation(ScrollMetrics position, double velocity) {
+    // If we're out of range and not headed back in range, defer to the parent
+    // ballistics, which should put us back in range at a page boundary.
+    if ((velocity <= 0.0 && position.pixels <= position.minScrollExtent) ||
+        (velocity >= 0.0 && position.pixels >= position.maxScrollExtent))
+      return super.createBallisticSimulation(position, velocity);
+    final Tolerance tolerance = this.tolerance;
+    final double target = _getTargetPixels(position, tolerance, velocity);
+    if (target != position.pixels)
+      return ScrollSpringSimulation(spring, position.pixels, target, velocity, tolerance: tolerance);
+    return null;
+  }
+
+  @override
+  bool get allowImplicitScrolling => false;
+}
+
+// Having this global (mutable) page controller is a bit of a hack. We need it
+// to plumb in the factory for _PagePosition, but it will end up accumulating
+// a large list of scroll positions. As long as you don't try to actually
+// control the scroll positions, everything should be fine.
+final PageController _defaultPageController = PageController();
+const PageScrollPhysics _kPagePhysics = PageScrollPhysics();
+
+/// A scrollable list that works page by page.
+///
+/// Each child of a page view is forced to be the same size as the viewport.
+///
+/// You can use a [PageController] to control which page is visible in the view.
+/// In addition to being able to control the pixel offset of the content inside
+/// the [PageView], a [PageController] also lets you control the offset in terms
+/// of pages, which are increments of the viewport size.
+///
+/// The [PageController] can also be used to control the
+/// [PageController.initialPage], which determines which page is shown when the
+/// [PageView] is first constructed, and the [PageController.viewportFraction],
+/// which determines the size of the pages as a fraction of the viewport size.
+///
+/// {@youtube 560 315 https://www.youtube.com/watch?v=J1gE9xvph-A}
+///
+/// {@tool dartpad --template=stateless_widget_scaffold}
+///
+/// Here is an example of [PageView]. It creates a centered [Text] in each of the three pages
+/// which scroll horizontally.
+///
+/// ```dart
+///  Widget build(BuildContext context) {
+///    final controller = PageController(initialPage: 0);
+///    return PageView(
+///      /// [PageView.scrollDirection] defaults to [Axis.horizontal].
+///      /// Use [Axis.vertical] to scroll vertically.
+///      scrollDirection: Axis.horizontal,
+///      controller: controller,
+///      children: [
+///        Center(
+///          child: Text("First Page"),
+///        ),
+///        Center(
+///          child: Text("Second Page"),
+///        ),
+///        Center(
+///          child: Text("Third Page"),
+///        )
+///      ],
+///    );
+///  }
+/// ```
+/// {@end-tool}
+///
+/// See also:
+///
+///  * [PageController], which controls which page is visible in the view.
+///  * [SingleChildScrollView], when you need to make a single child scrollable.
+///  * [ListView], for a scrollable list of boxes.
+///  * [GridView], for a scrollable grid of boxes.
+///  * [ScrollNotification] and [NotificationListener], which can be used to watch
+///    the scroll position without using a [ScrollController].
+class PageView extends StatefulWidget {
+  /// Creates a scrollable list that works page by page from an explicit [List]
+  /// of widgets.
+  ///
+  /// This constructor is appropriate for page views with a small number of
+  /// children because constructing the [List] requires doing work for every
+  /// child that could possibly be displayed in the page view, instead of just
+  /// those children that are actually visible.
+  ///
+  /// Like other widgets in the framework, this widget expects that
+  /// the [children] list will not be mutated after it has been passed in here.
+  /// See the documentation at [SliverChildListDelegate.children] for more details.
+  ///
+  /// {@template flutter.widgets.PageView.allowImplicitScrolling}
+  /// The [allowImplicitScrolling] parameter must not be null. If true, the
+  /// [PageView] will participate in accessibility scrolling more like a
+  /// [ListView], where implicit scroll actions will move to the next page
+  /// rather than into the contents of the [PageView].
+  /// {@endtemplate}
+  PageView({
+    Key? key,
+    this.scrollDirection = Axis.horizontal,
+    this.reverse = false,
+    PageController? controller,
+    this.physics,
+    this.pageSnapping = true,
+    this.onPageChanged,
+    List<Widget> children = const <Widget>[],
+    this.dragStartBehavior = DragStartBehavior.start,
+    this.allowImplicitScrolling = false,
+    this.preloadPagesCount = 1,
+    this.restorationId,
+    this.clipBehavior = Clip.hardEdge,
+  }) : assert(allowImplicitScrolling != null),
+       assert(preloadPagesCount != null),
+       assert(clipBehavior != null),
+       controller = controller ?? _defaultPageController,
+       childrenDelegate = SliverChildListDelegate(children),
+       super(key: key);
+
+  /// Creates a scrollable list that works page by page using widgets that are
+  /// created on demand.
+  ///
+  /// This constructor is appropriate for page views with a large (or infinite)
+  /// number of children because the builder is called only for those children
+  /// that are actually visible.
+  ///
+  /// Providing a non-null [itemCount] lets the [PageView] compute the maximum
+  /// scroll extent.
+  ///
+  /// [itemBuilder] will be called only with indices greater than or equal to
+  /// zero and less than [itemCount].
+  ///
+  /// [PageView.builder] by default does not support child reordering. If
+  /// you are planning to change child order at a later time, consider using
+  /// [PageView] or [PageView.custom].
+  ///
+  /// {@macro flutter.widgets.PageView.allowImplicitScrolling}
+  PageView.builder({
+    Key? key,
+    this.scrollDirection = Axis.horizontal,
+    this.reverse = false,
+    PageController? controller,
+    this.physics,
+    this.pageSnapping = true,
+    this.onPageChanged,
+    required IndexedWidgetBuilder itemBuilder,
+    int? itemCount,
+    this.dragStartBehavior = DragStartBehavior.start,
+    this.allowImplicitScrolling = false,
+    this.preloadPagesCount = 1,
+    this.restorationId,
+    this.clipBehavior = Clip.hardEdge,
+  }) : assert(allowImplicitScrolling != null),
+       assert(preloadPagesCount != null),
+       assert(clipBehavior != null),
+       controller = controller ?? _defaultPageController,
+       childrenDelegate = SliverChildBuilderDelegate(itemBuilder, childCount: itemCount),
+       super(key: key);
+
+  /// Creates a scrollable list that works page by page with a custom child
+  /// model.
+  ///
+  /// {@tool snippet}
+  ///
+  /// This [PageView] uses a custom [SliverChildBuilderDelegate] to support child
+  /// reordering.
+  ///
+  /// ```dart
+  /// class MyPageView extends StatefulWidget {
+  ///   @override
+  ///   _MyPageViewState createState() => _MyPageViewState();
+  /// }
+  ///
+  /// class _MyPageViewState extends State<MyPageView> {
+  ///   List<String> items = <String>['1', '2', '3', '4', '5'];
+  ///
+  ///   void _reverse() {
+  ///     setState(() {
+  ///       items = items.reversed.toList();
+  ///     });
+  ///   }
+  ///
+  ///   @override
+  ///   Widget build(BuildContext context) {
+  ///     return Scaffold(
+  ///       body: SafeArea(
+  ///         child: PageView.custom(
+  ///           childrenDelegate: SliverChildBuilderDelegate(
+  ///             (BuildContext context, int index) {
+  ///               return KeepAlive(
+  ///                 data: items[index],
+  ///                 key: ValueKey<String>(items[index]),
+  ///               );
+  ///             },
+  ///             childCount: items.length,
+  ///             findChildIndexCallback: (Key key) {
+  ///               final ValueKey<String> valueKey = key as ValueKey<String>;
+  ///               final String data = valueKey.value;
+  ///               return items.indexOf(data);
+  ///             }
+  ///           ),
+  ///         ),
+  ///       ),
+  ///       bottomNavigationBar: BottomAppBar(
+  ///         child: Row(
+  ///           mainAxisAlignment: MainAxisAlignment.center,
+  ///           children: <Widget>[
+  ///             TextButton(
+  ///               onPressed: () => _reverse(),
+  ///               child: Text('Reverse items'),
+  ///             ),
+  ///           ],
+  ///         ),
+  ///       ),
+  ///     );
+  ///   }
+  /// }
+  ///
+  /// class KeepAlive extends StatefulWidget {
+  ///   const KeepAlive({Key? key, required this.data}) : super(key: key);
+  ///
+  ///   final String data;
+  ///
+  ///   @override
+  ///   _KeepAliveState createState() => _KeepAliveState();
+  /// }
+  ///
+  /// class _KeepAliveState extends State<KeepAlive> with AutomaticKeepAliveClientMixin{
+  ///   @override
+  ///   bool get wantKeepAlive => true;
+  ///
+  ///   @override
+  ///   Widget build(BuildContext context) {
+  ///     super.build(context);
+  ///     return Text(widget.data);
+  ///   }
+  /// }
+  /// ```
+  /// {@end-tool}
+  ///
+  /// {@macro flutter.widgets.PageView.allowImplicitScrolling}
+  PageView.custom({
+    Key? key,
+    this.scrollDirection = Axis.horizontal,
+    this.reverse = false,
+    PageController? controller,
+    this.physics,
+    this.pageSnapping = true,
+    this.onPageChanged,
+    required this.childrenDelegate,
+    this.dragStartBehavior = DragStartBehavior.start,
+    this.allowImplicitScrolling = false,
+    this.preloadPagesCount = 1,
+    this.restorationId,
+    this.clipBehavior = Clip.hardEdge,
+  }) : assert(childrenDelegate != null),
+       assert(allowImplicitScrolling != null),
+       assert(preloadPagesCount != null),
+       assert(clipBehavior != null),
+       controller = controller ?? _defaultPageController,
+       super(key: key);
+
+  /// Controls whether the widget's pages will respond to
+  /// [RenderObject.showOnScreen], which will allow for implicit accessibility
+  /// scrolling.
+  ///
+  /// With this flag set to false, when accessibility focus reaches the end of
+  /// the current page and the user attempts to move it to the next element, the
+  /// focus will traverse to the next widget outside of the page view.
+  ///
+  /// With this flag set to true, when accessibility focus reaches the end of
+  /// the current page and user attempts to move it to the next element, focus
+  /// will traverse to the next page in the page view.
+  final bool allowImplicitScrolling;
+
+  /// {@macro flutter.widgets.scrollable.restorationId}
+  final String? restorationId;
+
+  /// The axis along which the page view scrolls.
+  ///
+  /// Defaults to [Axis.horizontal].
+  final Axis scrollDirection;
+
+  /// Whether the page view scrolls in the reading direction.
+  ///
+  /// For example, if the reading direction is left-to-right and
+  /// [scrollDirection] is [Axis.horizontal], then the page view scrolls from
+  /// left to right when [reverse] is false and from right to left when
+  /// [reverse] is true.
+  ///
+  /// Similarly, if [scrollDirection] is [Axis.vertical], then the page view
+  /// scrolls from top to bottom when [reverse] is false and from bottom to top
+  /// when [reverse] is true.
+  ///
+  /// Defaults to false.
+  final bool reverse;
+
+  /// An object that can be used to control the position to which this page
+  /// view is scrolled.
+  final PageController controller;
+
+  /// How the page view should respond to user input.
+  ///
+  /// For example, determines how the page view continues to animate after the
+  /// user stops dragging the page view.
+  ///
+  /// The physics are modified to snap to page boundaries using
+  /// [PageScrollPhysics] prior to being used.
+  ///
+  /// Defaults to matching platform conventions.
+  final ScrollPhysics? physics;
+
+  /// Set to false to disable page snapping, useful for custom scroll behavior.
+  final bool pageSnapping;
+
+  /// Called whenever the page in the center of the viewport changes.
+  final ValueChanged<int>? onPageChanged;
+
+  /// A delegate that provides the children for the [PageView].
+  ///
+  /// The [PageView.custom] constructor lets you specify this delegate
+  /// explicitly. The [PageView] and [PageView.builder] constructors create a
+  /// [childrenDelegate] that wraps the given [List] and [IndexedWidgetBuilder],
+  /// respectively.
+  final SliverChildDelegate childrenDelegate;
+
+  /// {@macro flutter.widgets.scrollable.dragStartBehavior}
+  final DragStartBehavior dragStartBehavior;
+
+  /// {@macro flutter.material.Material.clipBehavior}
+  ///
+  /// Defaults to [Clip.hardEdge].
+  final Clip clipBehavior;
+
+  /// An integer value that determines number pages that will be preloaded.															  
+  ///
+  /// [preloadPagesCount] value start from 0, default 1
+  final int preloadPagesCount;
+
+  @override
+  _PageViewState createState() => _PageViewState();
+}
+
+class _PageViewState extends State<PageView> {
+  int _lastReportedPage = 0;
+  int _preloadPagesCount = 1;
+
+  @override
+  void initState() {
+    super.initState();
+    _lastReportedPage = widget.controller.initialPage;
+    _preloadPagesCount = widget.preloadPagesCount;
+  }
+
+  AxisDirection _getDirection(BuildContext context) {
+    switch (widget.scrollDirection) {
+      case Axis.horizontal:
+        assert(debugCheckHasDirectionality(context));
+        final TextDirection textDirection = Directionality.of(context);
+        final AxisDirection axisDirection = textDirectionToAxisDirection(textDirection);
+        return widget.reverse ? flipAxisDirection(axisDirection) : axisDirection;
+      case Axis.vertical:
+        return widget.reverse ? AxisDirection.up : AxisDirection.down;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final AxisDirection axisDirection = _getDirection(context);
+    final ScrollPhysics physics = _ForceImplicitScrollPhysics(
+      allowImplicitScrolling: widget.allowImplicitScrolling,
+    ).applyTo(widget.pageSnapping
+        ? _kPagePhysics.applyTo(widget.physics)
+        : widget.physics);
+
+    return NotificationListener<ScrollNotification>(
+      onNotification: (ScrollNotification notification) {
+        if (notification.depth == 0 && widget.onPageChanged != null && notification is ScrollUpdateNotification) {
+          final PageMetrics metrics = notification.metrics as PageMetrics;
+          final int currentPage = metrics.page!.round();
+          if (currentPage != _lastReportedPage) {
+            _lastReportedPage = currentPage;
+            widget.onPageChanged!(currentPage);
+          }
+        }
+        return false;
+      },
+      child: Scrollable(
+        dragStartBehavior: widget.dragStartBehavior,
+        axisDirection: axisDirection,
+        controller: widget.controller,
+        physics: physics,
+        restorationId: widget.restorationId,
+        viewportBuilder: (BuildContext context, ViewportOffset position) {
+          return Viewport(
+            // TODO(dnfield): we should provide a way to set cacheExtent
+            // independent of implicit scrolling:
+            // https://github.com/flutter/flutter/issues/45632
+            //cacheExtent: widget.allowImplicitScrolling ? 1.0 : 0.0,
+            cacheExtent: _preloadPagesCount < 1
+                ? 0
+                : (_preloadPagesCount == 1
+                    ? 1
+                    : widget.scrollDirection == Axis.horizontal
+                        ? MediaQuery.of(context).size.width *
+                                _preloadPagesCount - 1
+                        : MediaQuery.of(context).size.height *
+                                _preloadPagesCount - 1),
+            cacheExtentStyle: CacheExtentStyle.viewport,
+            axisDirection: axisDirection,
+            offset: position,
+            clipBehavior: widget.clipBehavior,
+            slivers: <Widget>[
+              SliverFillViewport(
+                viewportFraction: widget.controller.viewportFraction,
+                delegate: widget.childrenDelegate,
+              ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder description) {
+    super.debugFillProperties(description);
+    description.add(EnumProperty<Axis>('scrollDirection', widget.scrollDirection));
+    description.add(FlagProperty('reverse', value: widget.reverse, ifTrue: 'reversed'));
+    description.add(DiagnosticsProperty<PageController>('controller', widget.controller, showName: false));
+    description.add(DiagnosticsProperty<ScrollPhysics>('physics', widget.physics, showName: false));
+    description.add(FlagProperty('pageSnapping', value: widget.pageSnapping, ifFalse: 'snapping disabled'));
+    description.add(FlagProperty('allowImplicitScrolling', value: widget.allowImplicitScrolling, ifTrue: 'allow implicit scrolling'));
+  }
+}

--- a/lib/widgets/ScrollingText.dart
+++ b/lib/widgets/ScrollingText.dart
@@ -1,12 +1,14 @@
 import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
 
 class ScrollingText extends StatefulWidget {
   String text;
   int size;
   String mode;
+  Color textColor;
   @override
   _ScrollingTextState createState() => _ScrollingTextState();
-  ScrollingText(this.text,this.size,this.mode);
+  ScrollingText(this.text, this.size, this.mode,this.textColor);
 }
 
 class _ScrollingTextState extends State<ScrollingText> {
@@ -31,12 +33,14 @@ class _ScrollingTextState extends State<ScrollingText> {
 
   @override
   Widget build(BuildContext context) {
-    if ((counter + widget.size) > widget.text.length && counter != 0){
-      setState(() {
-        initState();
-      });
-    } else if ((counter + widget.size) > widget.text.length){
-      return Text(widget.text, textAlign: TextAlign.left);
+    if ((counter + widget.size) > widget.text.length){
+      if(counter != 0) {
+        setState(() {
+          initState();
+        });
+      } else {
+        return Text(widget.text, textAlign: TextAlign.left, style: TextStyle(color: widget.textColor));
+      }
     } else {
       switch(widget.mode){
         case ("bounce"):
@@ -53,7 +57,7 @@ class _ScrollingTextState extends State<ScrollingText> {
           break;
       }
     }
-    return Text(displayText!, textAlign: TextAlign.left);
+    return Text(displayText!, textAlign: TextAlign.left, style: TextStyle(color: widget.textColor));
   }
   void bounce(){
     Future.delayed(const Duration(milliseconds: stepDelay), () {

--- a/lib/widgets/StaggeredView.dart
+++ b/lib/widgets/StaggeredView.dart
@@ -1,4 +1,3 @@
-import 'dart:math';
 import 'package:LoliSnatcher/ServiceHandler.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
@@ -9,14 +8,10 @@ import 'package:get/get.dart';
 import 'package:LoliSnatcher/SearchGlobals.dart';
 import 'package:LoliSnatcher/SnatchHandler.dart';
 import 'package:LoliSnatcher/SettingsHandler.dart';
+import 'package:LoliSnatcher/ViewUtils.dart';
 
 import 'package:LoliSnatcher/libBooru/BooruHandlerFactory.dart';
-import 'package:LoliSnatcher/libBooru/BooruItem.dart';
-import 'package:LoliSnatcher/widgets/CachedThumb.dart';
 import 'package:LoliSnatcher/widgets/ViewerPage.dart';
-
-import '../Tools.dart';
-import '../ViewUtils.dart';
 
 
 class StaggeredView extends StatefulWidget {

--- a/lib/widgets/TagSearchBox.dart
+++ b/lib/widgets/TagSearchBox.dart
@@ -12,7 +12,8 @@ class TagSearchBox extends StatefulWidget {
   TextEditingController searchTagsController;
   FocusNode _focusNode;
   SettingsHandler settingsHandler;
-  TagSearchBox(this.searchGlobals, this.searchTagsController, this._focusNode, this.settingsHandler);
+  Function searchAction;
+  TagSearchBox(this.searchGlobals, this.searchTagsController, this._focusNode, this.settingsHandler, this.searchAction);
   @override
   _TagSearchBoxState createState() => _TagSearchBoxState();
 }
@@ -32,10 +33,19 @@ class _TagSearchBoxState extends State<TagSearchBox> {
     widget._focusNode.addListener(_updateOverLay);
   }
 
+  void updateOverlay() {
+    setState(() {
+      if (this._overlayEntry != null) {
+        this._overlayEntry!.remove();
+      }
+      this._updateOverLay();
+    });
+  }
+
   void _updateOverLay() {
     if (widget._focusNode.hasFocus) {
       print("textbox is focused");
-      //this._overlayEntry = this._createOverlayEntry();
+      this._overlayEntry = this._createOverlayEntry();
       if (this._overlayEntry != null) {
         Overlay.of(context)!.insert(this._overlayEntry!);
       }
@@ -51,9 +61,9 @@ class _TagSearchBoxState extends State<TagSearchBox> {
     widget._focusNode.unfocus();
     super.dispose();
   }
-/*
-  OverlayEntry _createOverlayEntry() {
-    RenderObject renderBox = context.findRenderObject()!;
+
+  OverlayEntry? _createOverlayEntry() {
+    RenderBox renderBox = context.findRenderObject()! as RenderBox;
     setBooruHandler();
     widget.searchGlobals.booruHandler!.limit = 20;
     var size = renderBox.size;
@@ -69,8 +79,12 @@ class _TagSearchBoxState extends State<TagSearchBox> {
     }
     if (widget.searchGlobals.booruHandler!.tagSearchEnabled) {
       String input = widget.searchTagsController.text;
-      if (input.split(" ").length > 1) {
-        input = input.split(" ")[input.split(" ").length - 1];
+      List<String> splitInput = input.split(" ");
+      String lastTag = input;
+      if (splitInput.length > 1) {
+        // Get last tag in the input and remove minus (exclude symbol)
+        // TODO /bug?: use the tag behind the current cursor position, not the last tag
+        lastTag = splitInput[splitInput.length - 1].replaceAll(new RegExp(r'^-'), '');
       }
       return OverlayEntry(
         builder: (context) => Positioned(
@@ -81,7 +95,7 @@ class _TagSearchBoxState extends State<TagSearchBox> {
           child: Material(
             elevation: 4.0,
             child: FutureBuilder(
-                future: widget.searchGlobals.booruHandler!.tagSearch(input),
+                future: widget.searchGlobals.booruHandler!.tagSearch(lastTag),
                 builder: (BuildContext context, AsyncSnapshot snapshot) {
                   if ((snapshot.connectionState == ConnectionState.done) &&
                       snapshot.data.length > 0) {
@@ -94,15 +108,15 @@ class _TagSearchBoxState extends State<TagSearchBox> {
                             return ListTile(
                                 title: Text(snapshot.data[index]),
                                 onTap: (() {
-                                  widget._focusNode.unfocus();
-                                  widget.searchTagsController.text = widget
-                                          .searchTagsController.text
-                                          .substring(
-                                              0,
-                                              widget.searchTagsController.text
-                                                      .lastIndexOf(" ") +
-                                                  1) +
-                                      snapshot.data[index];
+                                  // widget._focusNode.unfocus();
+                                  // Keep minus if its in the beggining of current (last) tag
+                                  bool isExclude = new RegExp(r'^-').hasMatch(splitInput[splitInput.length - 1]);
+                                  String newInput = input.substring(0, input.lastIndexOf(" ") + 1) + (isExclude ? '-' : '') + snapshot.data[index] + " ";
+                                  widget.searchTagsController.text = newInput;
+
+                                  // Set the cursor to the end of the search and reset the overlay data
+                                  widget.searchTagsController.selection = TextSelection.fromPosition(TextPosition(offset: newInput.length));
+                                  updateOverlay();
                                 }));
                           });
                     } else {
@@ -116,34 +130,40 @@ class _TagSearchBoxState extends State<TagSearchBox> {
         ),
       );
     }
-  }*/
+  }
 
   @override
   Widget build(BuildContext context) {
     return Expanded(
-        child: TextField(
-      controller: widget.searchTagsController,
-      focusNode: widget._focusNode,
-      onChanged: (text) {
-        setState(() {
-          if (this._overlayEntry != null) {
-            this._overlayEntry!.remove();
-          }
-          this._updateOverLay();
-        });
-      },
-      onEditingComplete: (){
-        widget._focusNode.unfocus();
-      },
-      decoration: InputDecoration(
-        hintText: "Enter Tags",
-        contentPadding:
-            new EdgeInsets.fromLTRB(15, 0, 15, 0), // left,top,right,bottom
-        border: new OutlineInputBorder(
-          borderRadius: new BorderRadius.circular(50),
-          gapPadding: 0,
+      child: TextField(
+        controller: widget.searchTagsController,
+        focusNode: widget._focusNode,
+        onChanged: (text) {
+          updateOverlay();
+        },
+        onSubmitted: (String text) {
+          widget.searchAction(text);
+          widget._focusNode.unfocus();
+        },
+        onEditingComplete: (){
+          widget._focusNode.unfocus();
+        },
+        decoration: InputDecoration(
+          hintText: "Enter Tags",
+          suffixIcon: widget.searchTagsController.text.length > 0
+            ? IconButton(
+              padding: const EdgeInsets.all(5),
+              onPressed: () => widget.searchTagsController.clear(),
+              icon: Icon(Icons.clear),
+            )
+            : Container(width: 0.0),
+          contentPadding: EdgeInsets.fromLTRB(15, 0, 0, 0), // left,top,right,bottom
+          border: new OutlineInputBorder(
+            borderRadius: new BorderRadius.circular(50),
+            gapPadding: 0,
+          ),
         ),
-      ),
-    ));
+      )
+    );
   }
 }

--- a/lib/widgets/VideoApp.dart
+++ b/lib/widgets/VideoApp.dart
@@ -1,11 +1,14 @@
 import 'dart:io';
 import 'dart:ui';
-import 'dart:math';
 import 'dart:async';
+import 'dart:typed_data';
+
 import 'package:http/http.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:get/get.dart';
+import 'package:http/io_client.dart';
+import 'package:photo_view/photo_view.dart';
 import 'package:video_player/video_player.dart';
 import 'package:chewie/chewie.dart';
 
@@ -19,33 +22,47 @@ class VideoApp extends StatefulWidget {
   final BooruItem booruItem;
   final int index;
   final int viewedIndex;
-  SettingsHandler settingsHandler;
+  final SettingsHandler settingsHandler;
   VideoApp(this.booruItem, this.index, this.viewedIndex, this.settingsHandler);
   @override
   _VideoAppState createState() => _VideoAppState();
 }
 
 class _VideoAppState extends State<VideoApp> {
+  PhotoViewScaleStateController scaleController = PhotoViewScaleStateController();
+  PhotoViewController viewController = PhotoViewController();
   late VideoPlayerController _videoController;
-  late ChewieController _chewieController;
+  ChewieController? _chewieController;
 
   // VideoPlayerValue _latestValue;
 
-  late String cacheMode;
+  String? cacheMode;
   final ImageWriter imageWriter = ImageWriter();
   int _total = 0, _received = 0;
-  bool isFromCache = false;
-  late StreamedResponse _response;
-  late File _video;
+  int _prevReceivedAmount = 0, _lastReceivedAmount = 0, _lastReceivedTime = 0, _startedAt = 0;
+  Timer? _checkInterval, _debounceBytes;
+  bool isFromCache = false, isStopped = false;
+
+  IOClient? _client;
+  StreamedResponse? _response;
+  StreamSubscription? _subscription;
+
   List<int> _bytes = [];
-  late StreamSubscription _subscription;
+  File? _video;
 
-  Future<void> _downloadImage() async {
-    final String filePath =
-        await imageWriter.getCachePath(widget.booruItem.fileURL!, 'media');
+  /// Author: [Nani-Sore] ///
+  Future<void> _downloadVideo() async {
+    _checkInterval?.cancel();
+    _checkInterval = Timer.periodic(new Duration(seconds: 1), (timer) {
+      // force restate every second to refresh all timers/indicators, even when loading has stopped
+      setState(() {});
+    });
+    isStopped = false;
+    _startedAt = DateTime.now().millisecondsSinceEpoch;
 
+    final String? filePath = await imageWriter.getCachePath(widget.booruItem.fileURL!, 'media');
     // If file is in cache - load
-    print(filePath);
+    // print(filePath);
     if (filePath != null) {
       final File file = File(filePath);
       await file.readAsBytes();
@@ -59,101 +76,172 @@ class _VideoAppState extends State<VideoApp> {
       return;
     }
 
-    // Start video if not cached and we use both methods of loading
-    if (cacheMode == 'Stream+Cache') {
+    // Start video now if stream mode is involved
+    if(!widget.settingsHandler.mediaCache) {
+      // Media caching disabled - don't cache videos
       initPlayer();
+      return;
+    } else {
+      switch (cacheMode) {
+        case 'Cache':
+          // Cache to device from custom request
+          break;
+
+        case 'Stream+Cache':
+          // Load and stream from default player network request, cache to device from custom request
+          // TODO: change video handler to allow viewing and caching from single network request
+          initPlayer();
+          break;
+
+        case 'Stream':
+        default:
+          // Only stream, notice the return
+          initPlayer();
+          return;
+      }
     }
 
     // Otherwise start loading and subscribe to progress
-    _response = await Client()
-        .send(Request('GET', Uri.parse(widget.booruItem.fileURL!)));
-    _total = _response.contentLength!;
+    _client = IOClient();
+    _response = await _client!.send(Request('GET', Uri.parse(widget.booruItem.fileURL!)));
+    _total = _response!.contentLength!;
 
-    _subscription = _response.stream.listen((value) {
-      //Restate only when just Caching or video is not initialized from network yet
-      if (cacheMode == 'Cache' || !(_videoController.value != null && _videoController.value.isInitialized)) {
-        setState(() {
-          _bytes.addAll(value);
-          _received += value.length;
-        });
-      } else {
-        _bytes.addAll(value);
-        _received += value.length;
-      }
-    });
-    _subscription.onDone(() async {
-      if (_received > (_total * 0.95)) {
+    _subscription = _response!.stream.listen(
+      _onBytesAdded,
+      onError: (e) {
+        killLoading();
+        print(e);
+      },
+      cancelOnError: true,
+      onDone: () async {
         // Sometimes stream ends before fully loading, so we require at least 95% loaded to write to cache
-        final File cacheFile = await imageWriter.writeCacheFromBytes(
-            widget.booruItem.fileURL!, _bytes, 'media');
-        if (cacheFile != null) {
-          //Restate only when just Caching
-          if (cacheMode == 'Cache') {
-            setState(() {
+        if (_received > (_total * 0.95)) {
+          final File? cacheFile = await imageWriter.writeCacheFromBytes(
+              widget.booruItem.fileURL!, _bytes, 'media');
+          if (cacheFile != null) {
+            //Restate only when just Caching
+            if (cacheMode == 'Cache') {
+              setState(() {
+                _video = cacheFile;
+                // Start video after caching
+                initPlayer();
+              });
+            } else {
               _video = cacheFile;
-            });
-          } else {
-            _video = cacheFile;
+            }
           }
-        }
 
-        // Start video after caching
-        if (cacheMode == 'Cache') {
-          initPlayer();
+          // clear bytes array
+          // _bytes = []
+        } else {
+          //TODO: show error message
+          killLoading();
+          print('Image load incomplete'); // Throw an error, allow to retry?
         }
-      } else {
-        print('Image load incomplete'); // Throw an error, allow to retry?
       }
-    });
+    );
+  }
+
+  /// Author: [Nani-Sore] ///
+  void _onBytesAdded(List<int> addedBytes) {
+    // always save incoming bytes, but restate only after [debounceDelay]MS
+    const int debounceDelay = 50;
+    bool isActive = _debounceBytes?.isActive ?? false;
+    bool isAllowedToRestate = cacheMode == 'Cache' || !(_videoController.value.isInitialized);
+    if (isActive || !isAllowedToRestate) {
+      _bytes.addAll(addedBytes);
+      _received += addedBytes.length;
+    } else {
+      setState(() {
+        _bytes.addAll(addedBytes);
+        _received += addedBytes.length;
+      });
+      _debounceBytes = Timer(const Duration(milliseconds: debounceDelay), () {});
+    }
   }
 
   @override
   void initState() {
     super.initState();
+    initVideo();
+  }
+
+  void initVideo() {
+    // viewController..outputStateStream.listen(onViewStateChanged);
+    // scaleController..outputScaleStateStream.listen(onScaleStateChanged);
     cacheMode = widget.settingsHandler.videoCacheMode!;
-    if (!widget.settingsHandler.mediaCache) {
-      initPlayer();
-      return;
-    }
-    switch (cacheMode) {
-      case "Stream":
-        initPlayer();
-        break;
-      case "Cache":
-      case "Stream+Cache":
-        _downloadImage();
-        break;
-    }
+    _downloadVideo();
+  }
+
+  void killLoading() {
+    _debounceBytes?.cancel();
+    _checkInterval?.cancel();
+    _subscription?.cancel();
+    _client?.close();
+
+    setState(() {
+      _total = 0;
+      _received = 0;
+
+      _prevReceivedAmount = 0;
+      _lastReceivedAmount = 0;
+      _lastReceivedTime = 0;
+      _startedAt = 0;
+
+      isFromCache = false;
+      isStopped = true;
+
+      _video = null;
+      _bytes = [];
+    });
   }
 
   @override
   void dispose() {
+    _debounceBytes?.cancel();
+    _checkInterval?.cancel();
+
     _videoController.pause();
     _videoController.dispose();
-    _chewieController.dispose();
-    _subscription.cancel();
+    _chewieController?.dispose();
+
+    _subscription?.cancel();
+    _client?.close();
     super.dispose();
   }
 
+
+  // debug functions
+  void onScaleStateChanged(PhotoViewScaleState scaleState) {
+    print(scaleState);
+  }
+
+  void onViewStateChanged(PhotoViewControllerValue viewState) {
+    print(viewState);
+  }
+
   // void _updateState() {
-  //   print(_controller.value);
+  //   print(_videoController.value);
   //   setState(() {
-  //     _latestValue = _controller.value;
+  //     _latestValue = _videoController.value;
   //   });
   // }
 
 
   Future<void> initPlayer() async {
     // Start from cache if was already cached or only caching is allowed
+    // mixWithOthers: true, allows to not interrupt audio sources from other apps
     if (widget.settingsHandler.mediaCache && _video != null) {
-      _videoController = VideoPlayerController.file(_video);
+      _videoController = VideoPlayerController.file(_video!, videoPlayerOptions: VideoPlayerOptions(mixWithOthers: true));
     } else {
       // Otherwise load from network
-      _videoController =
-          VideoPlayerController.network(widget.booruItem.fileURL!);
+      _videoController = VideoPlayerController.network(widget.booruItem.fileURL!, videoPlayerOptions: VideoPlayerOptions(mixWithOthers: true));
     }
-    await _videoController.initialize();
+    await Future.wait([_videoController.initialize()]);
     // _videoController.addListener(_updateState);
+
+    // Stop force restating loading indicators when video is initialized
+    _checkInterval?.cancel();
 
     // Player wrapper to allow controls, looping...
     _chewieController = ChewieController(
@@ -164,8 +252,8 @@ class _VideoAppState extends State<VideoApp> {
       looping: true,
       showControls: true,
       customControls:
-        //LoliControls(),
-        MaterialControls(),
+        LoliControls(),
+        // MaterialControls(),
         // CupertinoControls(
         //   backgroundColor: Color.fromRGBO(41, 41, 41, 0.7),
         //   iconColor: Color.fromARGB(255, 200, 200, 200)
@@ -201,25 +289,36 @@ class _VideoAppState extends State<VideoApp> {
     setState(() {});
   }
 
+  /// Author: [Nani-Sore] ///
   Widget loadingElementBuilder() {
-    bool hasProgressData =
-        widget.settingsHandler.mediaCache && _total > 0;
-    int expectedBytes = (hasProgressData ? _received : null)!;
-    int totalBytes = (hasProgressData ? _total : null)!;
-    double percentDone = 0;
-    if (hasProgressData){
-      percentDone = expectedBytes / totalBytes;
+    bool hasProgressData = widget.settingsHandler.mediaCache && _total > 0;
+    int expectedBytes = hasProgressData ? _received : 0;
+    int totalBytes = hasProgressData ? _total : 0;
+
+    double speedCheckInterval = 1000 / 4;
+    int nowMils = DateTime.now().millisecondsSinceEpoch;
+    if((nowMils - _lastReceivedTime) > speedCheckInterval && hasProgressData) {
+      _prevReceivedAmount = _lastReceivedAmount;
+      _lastReceivedAmount = expectedBytes;
+
+      _lastReceivedTime = nowMils;
     }
-    String loadedSize =
-        hasProgressData ? Tools.formatBytes(expectedBytes, 1) : '';
-    String expectedSize =
-        hasProgressData ? Tools.formatBytes(totalBytes, 1) : '';
+
+    double? percentDone = hasProgressData ? (expectedBytes / totalBytes) : null;
+    String loadedSize = hasProgressData ? Tools.formatBytes(expectedBytes, 1) : '';
+    String expectedSize = hasProgressData ? Tools.formatBytes(totalBytes, 1) : '';
+
+    int expectedSpeed = hasProgressData ? ((_lastReceivedAmount - _prevReceivedAmount) * (1000 / speedCheckInterval).round()) : 0;
+    String expectedSpeedText = hasProgressData ? (Tools.formatBytes(expectedSpeed, 1) + '/s') : '';
+    double expectedTime = hasProgressData ? ((totalBytes - expectedBytes) / expectedSpeed) : 0;
+    String expectedTimeText = (hasProgressData && expectedTime > 0) ? ("~" + expectedTime.toStringAsFixed(1) + " second${expectedTime == 1 ? '' : 's'} left") : '';
+    int sinceStart = Duration(milliseconds: nowMils - _startedAt).inSeconds;
+    String sinceStartText = "Started " + sinceStart.toString() + " second${sinceStart == 1 ? '' : 's'} ago";
 
     String percentDoneText = hasProgressData
-        ? ('${(percentDone * 100).toStringAsFixed(2)}%')
-        : 'Loading...';
-    String filesizeText =
-        hasProgressData ? ('$loadedSize / $expectedSize') : '';
+        ? (percentDone == 1 ? 'Rendering...' : '${(percentDone! * 100).toStringAsFixed(2)}%')
+        : 'Loading${isFromCache ? ' from cache' : ''}...';
+    String filesizeText = hasProgressData ? ('$loadedSize / $expectedSize') : '';
 
     String thumbnailFileURL = widget.booruItem.thumbnailURL!; // sample can be a video
     // widget.settingsHandler.previewMode == "Sample"
@@ -228,12 +327,13 @@ class _VideoAppState extends State<VideoApp> {
     File preview = File(
         "${widget.settingsHandler.cachePath}thumbnails/${thumbnailFileURL.substring(thumbnailFileURL.lastIndexOf("/") + 1)}");
     // start opacity from 20%
-    double opacityValue = 1;
-    //double opacityValue = hasProgressData ? 0.2 + 0.8 * lerpDouble(0.0, 1.0,percentDone) : 0.66;
-
-
+    double opacityValue = hasProgressData
+        ? 0.2 + 0.8 * lerpDouble(0.0, 1.0, percentDone ?? 0.66)!
+        : 0.66;
     // print(widget.settingsHandler.cachePath + "thumbnails/" + thumbnailFileURL.substring(thumbnailFileURL.lastIndexOf("/") + 1));
     // print(opacityValue);
+
+
     late ImageProvider provider;
     if (preview.existsSync()){
       provider = FileImage(preview);
@@ -271,11 +371,17 @@ class _VideoAppState extends State<VideoApp> {
                           ? [
                               Container(
                                   width: MediaQuery.of(context).size.width - 30,
-                                  child: Image(
-                                      image: AssetImage(
-                                          'assets/images/loading.gif')))
+                                  child: Image(image: AssetImage('assets/images/loading.gif')))
                             ]
-                          : [
+                          : (isStopped
+                            ? [TextButton.icon(
+                                icon: Icon(Icons.play_arrow),
+                                label: Text('Restart loading', style: TextStyle(color: Colors.white)),
+                                onPressed: () {
+                                  setState(() { initVideo(); });
+                                },
+                              )]
+                            : [
                               Stack(children: [
                                 Text(
                                   percentDoneText,
@@ -312,7 +418,70 @@ class _VideoAppState extends State<VideoApp> {
                                   ),
                                 ),
                               ]),
-                            ]),
+                              Stack(children: [
+                                Text(
+                                  expectedSpeedText,
+                                  style: TextStyle(
+                                    fontSize: 16,
+                                    foreground: Paint()
+                                      ..style = PaintingStyle.stroke
+                                      ..strokeWidth = 4
+                                      ..color = Colors.black,
+                                  ),
+                                ),
+                                Text(
+                                  expectedSpeedText,
+                                  style: TextStyle(
+                                    fontSize: 16,
+                                  ),
+                                ),
+                              ]),
+                              Stack(children: [
+                                Text(
+                                  expectedTimeText,
+                                  style: TextStyle(
+                                    fontSize: 16,
+                                    foreground: Paint()
+                                      ..style = PaintingStyle.stroke
+                                      ..strokeWidth = 4
+                                      ..color = Colors.black,
+                                  ),
+                                ),
+                                Text(
+                                  expectedTimeText,
+                                  style: TextStyle(
+                                    fontSize: 16,
+                                  ),
+                                ),
+                              ]),
+                              Stack(children: [
+                                Text(
+                                  sinceStartText,
+                                  style: TextStyle(
+                                    fontSize: 16,
+                                    foreground: Paint()
+                                      ..style = PaintingStyle.stroke
+                                      ..strokeWidth = 4
+                                      ..color = Colors.black,
+                                  ),
+                                ),
+                                Text(
+                                  sinceStartText,
+                                  style: TextStyle(
+                                    fontSize: 16,
+                                  ),
+                                ),
+                              ]),
+                              (widget.settingsHandler.mediaCache && cacheMode != 'Stream')
+                                ? TextButton.icon(
+                                  icon: Icon(Icons.stop),
+                                  label: Text('Stop loading', style: TextStyle(color: Colors.white)),
+                                  onPressed: killLoading,
+                                )
+                                : Text('')
+                            ]
+                          )
+                  ),
                   SizedBox(
                     width: 10,
                     child: RotatedBox(
@@ -332,9 +501,16 @@ class _VideoAppState extends State<VideoApp> {
   Widget build(BuildContext context) {
     bool isViewed = widget.viewedIndex == widget.index;
     bool initialized = _chewieController != null &&
-        _chewieController.videoPlayerController.value.isInitialized;
+        _chewieController!.videoPlayerController.value.isInitialized;
     // String vWidth = '';
     // String vHeight = '';
+
+    if (!isViewed) {
+      // reset zoom if not viewed
+      setState(() {
+        scaleController.scaleState = PhotoViewScaleState.initial;
+      });
+    }
 
     if (initialized) {
       // vWidth = _chewieController.videoPlayerController.value.size.width.toStringAsFixed(0);
@@ -357,7 +533,18 @@ class _VideoAppState extends State<VideoApp> {
     // ),
 
     return initialized
-      ? Chewie(controller: _chewieController)
+      ? PhotoView.customChild(
+          child: Chewie(controller: _chewieController!),
+          minScale: PhotoViewComputedScale.contained,
+          maxScale: PhotoViewComputedScale.covered * 8,
+          initialScale: PhotoViewComputedScale.contained,
+          enableRotation: false,
+          basePosition: Alignment.center,
+          controller: viewController,
+          // tightMode: true,
+          heroAttributes: PhotoViewHeroAttributes(tag: 'imageHero' + widget.index.toString()),
+          scaleStateController: scaleController,
+        )
       : loadingElementBuilder();
   }
 }

--- a/lib/widgets/ViewerPage.dart
+++ b/lib/widgets/ViewerPage.dart
@@ -1,10 +1,13 @@
 import 'dart:io';
+import 'dart:typed_data';
 import 'dart:ui';
+
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:get/get.dart';
 import 'package:photo_view/photo_view.dart';
-import 'package:preload_page_view/preload_page_view.dart';
+// import 'package:preload_page_view/preload_page_view.dart';
 import 'package:flutter/cupertino.dart';
 
 import 'package:LoliSnatcher/SearchGlobals.dart';
@@ -13,11 +16,13 @@ import 'package:LoliSnatcher/ServiceHandler.dart';
 import 'package:LoliSnatcher/SettingsHandler.dart';
 import 'package:LoliSnatcher/ImageWriter.dart';
 import 'package:LoliSnatcher/getPerms.dart';
-import 'package:LoliSnatcher/Tools.dart';
 
+import 'package:LoliSnatcher/libBooru/BooruItem.dart';
 import 'package:LoliSnatcher/widgets/MediaViewer.dart';
+import 'package:LoliSnatcher/widgets/PreloadPageView.dart' as PreloadPageView;
 import 'package:LoliSnatcher/widgets/VideoApp.dart';
 import 'package:LoliSnatcher/widgets/HideableAppbar.dart';
+import 'package:LoliSnatcher/widgets/InfoDialog.dart';
 
 /**
  * The image page is what is dispalyed when an iamge is clicked it shows a full resolution
@@ -38,14 +43,14 @@ class ViewerPage extends StatefulWidget {
 }
 
 class _ViewerPageState extends State<ViewerPage> {
-  late PreloadPageController controller;
-  late PageController controllerLinux;
+  PreloadPageView.PageController? controller;
+  PageController? controllerLinux;
   ImageWriter writer = new ImageWriter();
   FocusNode kbFocusNode = FocusNode();
   @override
   void initState() {
     super.initState();
-    controller = PreloadPageController(
+    controller = PreloadPageView.PageController(
       initialPage: widget.index,
     );
     controllerLinux = PageController(
@@ -60,14 +65,15 @@ class _ViewerPageState extends State<ViewerPage> {
 
   @override
   Widget build(BuildContext context) {
-    String appBarTitle =
-        "${(widget.searchGlobals.viewedIndex!.value + 1).toString()} / ${widget.fetched.length.toString()}";
+    String appBarTitle = "${(widget.searchGlobals.viewedIndex!.value + 1).toString()}/${widget.fetched.length.toString()}";
     kbFocusNode.requestFocus();
     return Scaffold(
-        appBar: HideableAppBar(appBarTitle, appBarActions(),
-            widget.searchGlobals, widget.settingsHandler.autoHideImageBar),
-        backgroundColor: Colors.transparent,
-        body: Dismissible(
+      appBar: HideableAppBar(appBarTitle, appBarActions(), widget.searchGlobals, widget.settingsHandler.autoHideImageBar),
+      backgroundColor: Colors.transparent,
+      body: PhotoViewGestureDetectorScope(
+        // vertical to prevent swipe-to-dismiss when zoomed
+        axis: Axis.vertical, // photo_view doesn't support locking both axises, so we use custom fork to fix for this
+        child: Dismissible(
           direction: DismissDirection.vertical,
           // background: Container(color: Colors.black.withOpacity(0.3)),
           key: const Key('imagePageDismissibleKey'),
@@ -75,10 +81,16 @@ class _ViewerPageState extends State<ViewerPage> {
           dismissThresholds: {DismissDirection.up: 0.2, DismissDirection.down: 0.2}, // Amount of swiped away which triggers dismiss
           onDismissed: (_) => Navigator.of(context).pop(),
           child: Center(
-            // The pageView builder will created a page for each image in the booruList(fetched)
-            child: Platform.isAndroid ? androidPageBuilder() : linuxPageBuilder(),
-          ),
-        ));
+            // child: PhotoViewGestureDetectorScope(
+            //   // horizontal to prevent triggering page change early when panning
+            //   axis: Axis.horizontal,
+              // The pageView builder will created a page for each image in the booruList(fetched)
+              child: Platform.isAndroid ? androidPageBuilder() : linuxPageBuilder(),
+            // ),
+          )
+        )
+      )
+    );
   }
   @override
   void dispose(){
@@ -91,64 +103,62 @@ class _ViewerPageState extends State<ViewerPage> {
       focusNode: kbFocusNode,
       onKey: (RawKeyEvent event){
         if(event.isKeyPressed(LogicalKeyboardKey.arrowRight) || event.isKeyPressed(LogicalKeyboardKey.keyH)){
-          controller.jumpToPage(widget.searchGlobals.viewedIndex!.value - 1);
+          controller?.jumpToPage(widget.searchGlobals.viewedIndex!.value - 1);
         } else if(event.isKeyPressed(LogicalKeyboardKey.arrowRight) || event.isKeyPressed(LogicalKeyboardKey.keyL)){
-          controller.jumpToPage(widget.searchGlobals.viewedIndex!.value + 1);
+          controller?.jumpToPage(widget.searchGlobals.viewedIndex!.value + 1);
         } else if (event.isKeyPressed(LogicalKeyboardKey.keyS)){
           widget.snatchHandler.queue([widget.fetched[widget.searchGlobals.viewedIndex!.value]], widget.settingsHandler.jsonWrite, widget.searchGlobals.selectedBooru!.name!,widget.settingsHandler.snatchCooldown);
         }
       },
-      child:PhotoViewGestureDetectorScope(
-        // prevents triggering page change early when panning
-          axis: Axis.horizontal,
-          child: PreloadPageView.builder(
-            preloadPagesCount: widget.settingsHandler.preloadCount,
-            scrollDirection: Axis.horizontal,
-            physics: const AlwaysScrollableScrollPhysics(),
-            itemBuilder: (context, index) {
-              String fileURL = widget.fetched[index].fileURL;
-              bool isVideo = widget.fetched[index].isVideo();
-              int preloadCount = widget.settingsHandler.preloadCount;
-              bool isViewed = widget.searchGlobals.viewedIndex!.value == index;
-              bool isNear =
-                  (widget.searchGlobals.viewedIndex!.value - index).abs() <=
-                      preloadCount;
-              // print('isVideo: '+isVideo.toString());
-
-              // Render only if viewed or in preloadCount range
-              if (isViewed || isNear) {
-                // Cut to the size of the container, prevents overlapping
-                return ClipRect(
-                    child: GestureDetector(
-                        onLongPress: () {
-                          print('longpress');
-                          widget.searchGlobals.displayAppbar!.value =
-                          !widget.searchGlobals.displayAppbar!.value;
-                        },
-                        child: isVideo
-                            ? VideoApp(
-                            widget.fetched[index],
-                            index,
-                            widget.searchGlobals.viewedIndex!.value,
-                            widget.settingsHandler)
-                            : MediaViewer(
-                            widget.fetched[index],
-                            index,
-                            widget.searchGlobals.viewedIndex!.value,
-                            widget.settingsHandler)));
-              } else {
-                return Container();
-              }
-            },
-            controller: controller,
-            onPageChanged: (int index) {
-              setState(() {
-                widget.searchGlobals.viewedIndex!.value = index;
-              });
-              // print('Page changed ' + index.toString());
-            },
-            itemCount: widget.fetched.length,
-          )) ,
+      child: PreloadPageView.PageView.builder( // PreloadPageView.builder(
+        preloadPagesCount: widget.settingsHandler.preloadCount,
+        allowImplicitScrolling: true,
+        scrollDirection: Axis.horizontal,
+        physics: const AlwaysScrollableScrollPhysics(),
+        itemBuilder: (context, index) {
+          String fileURL = widget.fetched[index].fileURL;
+          bool isVideo = widget.fetched[index].isVideo();
+          int preloadCount = widget.settingsHandler.preloadCount;
+          bool isViewed = widget.searchGlobals.viewedIndex!.value == index;
+          bool isNear = (widget.searchGlobals.viewedIndex!.value - index).abs() <= preloadCount;
+          // print(fileURL);
+          // print('isVideo: '+isVideo.toString());
+          // Render only if viewed or in preloadCount range
+          if (isViewed || isNear) {
+            // Cut to the size of the container, prevents overlapping
+            return ClipRect(
+                child: GestureDetector(
+                    onLongPress: () {
+                      print('longpress');
+                      widget.searchGlobals.displayAppbar!.value =
+                      !widget.searchGlobals.displayAppbar!.value;
+                    },
+                    child: isVideo
+                        ? VideoApp(
+                        widget.fetched[index],
+                        index,
+                        widget.searchGlobals.viewedIndex!.value,
+                        widget.settingsHandler)
+                        : MediaViewer(
+                        widget.fetched[index],
+                        index,
+                        widget.searchGlobals.viewedIndex!.value,
+                        widget.settingsHandler)));
+          } else {
+            return Container(
+              color: Colors.black,
+            );
+          }
+        },
+        controller: controller,
+        onPageChanged: (int index) {
+          setState(() {
+            widget.searchGlobals.viewedIndex!.value = index;
+          });
+          // print('Page changed ' + index.toString());
+        },
+        itemCount: widget.fetched.length,
+      ),
     );
   }
 
@@ -166,15 +176,17 @@ class _ViewerPageState extends State<ViewerPage> {
                   Image.network(widget.fetched[index].thumbnailURL),
                   Container(
                     margin: EdgeInsets.fromLTRB(10, 10, 10, 10),
-                    child: FlatButton(
-                      shape: RoundedRectangleBorder(
-                        borderRadius: new BorderRadius.circular(20),
-                        side: BorderSide(color: Get.context!.theme.accentColor),
+                    child: TextButton(
+                      style: TextButton.styleFrom(
+                        shape: RoundedRectangleBorder(
+                          borderRadius: new BorderRadius.circular(20),
+                          side: BorderSide(color: Get.context!.theme.accentColor),
+                        ),
                       ),
                       onPressed: () {
                         Process.run('mpv', ["--loop", fileURL]);
                       },
-                      child: Text("Open in MPV"),
+                      child: Text("Open in MPV", style: TextStyle(color: Colors.white)),
                     ),
                   )
                 ],
@@ -186,6 +198,89 @@ class _ViewerPageState extends State<ViewerPage> {
         });
   }
 
+
+  /// Author: [Nani-Sore] ///
+  void shareTextAction(String text) {
+    ServiceHandler serviceHandler = new ServiceHandler();
+    serviceHandler.loadShareTextIntent(text);
+  }
+
+  /// Author: [Nani-Sore] ///
+  void shareFileAction() async {
+    BooruItem item = widget.fetched[widget.searchGlobals.viewedIndex!.value];
+    String? path = await ImageWriter().getCachePath(item.fileURL!, 'media');
+    ServiceHandler serviceHandler = new ServiceHandler();
+    ImageWriter writer = new ImageWriter();
+
+    if(path != null) {
+      // File is already in cache - share from there
+      await serviceHandler.loadShareFileIntent(path, (item.isVideo() ? 'video' : 'image') + '/' + item.fileExt!);
+    } else {
+      // File not in cache - load from network, share, delete from cache afterwards
+      ServiceHandler.displayToast("Loading file from network...\nPlease wait");
+      var request = await HttpClient().getUrl(Uri.parse(item.fileURL!));
+      var response = await request.close();
+      Uint8List bytes = await consolidateHttpClientResponseBytes(response);
+      final File cacheFile = await writer.writeCacheFromBytes(item.fileURL!, bytes, 'media');
+      path = cacheFile.path;
+      await serviceHandler.loadShareFileIntent(path, (item.isVideo() ? 'video' : 'image') + '/' + item.fileExt!);
+
+      // TODO: find a way to detect when share menu was closed, orherwise this is triggered immediately and file is deleted before sending to another app
+      // writer.deleteFromCache(path, 'media');
+    }
+  }
+
+  /// Author: [Nani-Sore] ///
+  void showShareDialog({bool showTip = true}) {
+    Get.dialog(
+      InfoDialog('What to share',
+        [
+          TextButton(
+            style: TextButton.styleFrom(
+                shape: RoundedRectangleBorder(
+                  borderRadius: new BorderRadius.circular(20),
+                  side: BorderSide(color: Get.context!.theme.accentColor),
+                )
+            ),
+            onPressed: (){
+              Navigator.of(context).pop();
+              shareTextAction(widget.fetched[widget.searchGlobals.viewedIndex!.value].postURL);
+            },
+            child: Text('Post URL', style: TextStyle(color: Colors.white))
+          ),
+          TextButton(
+            style: TextButton.styleFrom(
+                shape: RoundedRectangleBorder(
+                  borderRadius: new BorderRadius.circular(20),
+                  side: BorderSide(color: Get.context!.theme.accentColor),
+                )
+            ),
+            onPressed: (){
+              Navigator.of(context).pop();
+              shareTextAction(widget.fetched[widget.searchGlobals.viewedIndex!.value].fileURL);
+            },
+            child: Text('File URL', style: TextStyle(color: Colors.white))
+          ),
+          TextButton(
+            style: TextButton.styleFrom(
+              shape: RoundedRectangleBorder(
+                borderRadius: new BorderRadius.circular(20),
+                side: BorderSide(color: Get.context!.theme.accentColor),
+              )
+            ),
+            onPressed: (){
+              Navigator.of(context).pop();
+              shareFileAction();
+            },
+            child: Text('File', style: TextStyle(color: Colors.white))
+          ),
+          Text(showTip ? '[Tip]: You can set default action in settings' : '')
+        ],
+        CrossAxisAlignment.center,
+      )
+    );
+  }
+
   List<Widget> appBarActions() {
     return [
       IconButton(
@@ -193,16 +288,38 @@ class _ViewerPageState extends State<ViewerPage> {
         onPressed: () async {
           getPerms();
           // call a function to save the currently viewed image when the save button is pressed
-          widget.snatchHandler.queue([widget.fetched[widget.searchGlobals.viewedIndex!.value]], widget.settingsHandler.jsonWrite, widget.searchGlobals.selectedBooru!.name!,widget.settingsHandler.snatchCooldown);
+          widget.snatchHandler.queue([widget.fetched[widget.searchGlobals.viewedIndex!.value]], widget.settingsHandler.jsonWrite, widget.searchGlobals.selectedBooru!.name!, widget.settingsHandler.snatchCooldown);
         },
       ),
-      IconButton(
-        icon: Icon(Icons.share),
-        onPressed: () {
-          ServiceHandler serviceHandler = new ServiceHandler();
-          serviceHandler.loadShareIntent(
-              widget.fetched[widget.searchGlobals.viewedIndex!.value].fileURL);
+      GestureDetector(
+        onTap: () async {
+          String shareSetting = widget.settingsHandler.shareAction!;
+          switch(shareSetting) {
+            case 'Post URL':
+              shareTextAction(widget.fetched[widget.searchGlobals.viewedIndex!.value].postURL);
+              break;
+            case 'File URL':
+              shareTextAction(widget.fetched[widget.searchGlobals.viewedIndex!.value].fileURL);
+              break;
+            case 'File':
+              shareFileAction();
+              break;
+
+            case 'Ask':
+            default:
+              showShareDialog();
+              break;
+          }
         },
+        onLongPress: () {
+          // Ignore share setting on long press
+          showShareDialog(showTip: false);
+        },
+        child: Icon(
+          Icons.share,
+          // icon color sets incorrectly when it's inside gesturedetector, so we force it
+          color: Get.context!.theme.primaryIconTheme.color,
+        )
       ),
       widget.settingsHandler.dbEnabled ?
       IconButton(

--- a/lib/widgets/WaterfallView.dart
+++ b/lib/widgets/WaterfallView.dart
@@ -1,5 +1,3 @@
-import 'dart:math';
-import 'package:LoliSnatcher/ServiceHandler.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -9,13 +7,10 @@ import 'package:LoliSnatcher/SearchGlobals.dart';
 import 'package:LoliSnatcher/SnatchHandler.dart';
 import 'package:LoliSnatcher/SettingsHandler.dart';
 
+import 'package:LoliSnatcher/ViewUtils.dart';
+import 'package:LoliSnatcher/ServiceHandler.dart';
 import 'package:LoliSnatcher/libBooru/BooruHandlerFactory.dart';
-import 'package:LoliSnatcher/libBooru/BooruItem.dart';
-import 'package:LoliSnatcher/widgets/CachedThumb.dart';
 import 'package:LoliSnatcher/widgets/ViewerPage.dart';
-
-import '../Tools.dart';
-import '../ViewUtils.dart';
 
 
 class WaterfallView extends StatefulWidget {
@@ -61,7 +56,7 @@ class _WaterfallState extends State<WaterfallView> {
   @override
   Widget build(BuildContext context) {
     // super.build(context);
-    //
+
     if (FocusScope.of(context).focusedChild == null){
       print("kb focus node requesting focus");
       kbFocusNode.requestFocus();
@@ -116,8 +111,7 @@ class _WaterfallState extends State<WaterfallView> {
                     gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
                         crossAxisCount: columnsCount),
                     itemBuilder: (BuildContext context, int index) {
-                      bool isSelected =
-                      widget.searchGlobals.selected!.contains(index);
+                      bool isSelected = widget.searchGlobals.selected!.contains(index);
                       return new Card(
                         child: new GridTile(
                           // Inkresponse is used so the tile can have an onclick function
@@ -141,10 +135,8 @@ class _WaterfallState extends State<WaterfallView> {
                                   // Load the image viewer
                                   kbFocusNode.unfocus();
                                   Get.dialog(
-                                    ViewerPage(
-                                        snapshot.data, index, widget.searchGlobals, widget.settingsHandler, widget.snatchHandler),
-                                    transitionDuration:
-                                    Duration(milliseconds: 200),
+                                    ViewerPage(snapshot.data, index, widget.searchGlobals, widget.settingsHandler, widget.snatchHandler),
+                                    transitionDuration: Duration(milliseconds: 200),
                                     // barrierColor: Colors.transparent
                                   ).whenComplete(() {
                                     SystemChrome.setEnabledSystemUIOverlays(SystemUiOverlay.values);
@@ -154,8 +146,7 @@ class _WaterfallState extends State<WaterfallView> {
                                   // Get.to(ImagePage(snapshot.data, index, widget.searchGlobals, widget.settingsHandler, widget.snatchHandler));
                                 },
                                 onLongPress: () {
-                                  if (widget.searchGlobals.selected!
-                                      .contains(index)) {
+                                  if (widget.searchGlobals.selected!.contains(index)) {
                                     setState(() {
                                       widget.searchGlobals.selected!.remove(index);
                                     });

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,18 +29,17 @@ dependencies:
   permission_handler: ^6.0.0
   image: ^3.0.1
   google_fonts: ^2.0.0
-  photo_view:
+  photo_view: # ^0.10.3
     git:
-      url: "https://github.com/DevNico/photo_view.git"
+      url: "https://github.com/NANI-SORE/photo_view.git"
   html: ^0.15.0
   flutter_staggered_grid_view: ^0.4.0-nullsafety.3
   video_player: ^2.0.0
   chewie: ^1.0.0
   sqflite: ^2.0.0+2
-  preload_page_view:
-    git:
-      url: "https://github.com/octomato/preload_page_view.git"
-  flutter_icons:
+  # preload_page_view: ^0.1.5
+
+flutter_icons:
 flutter_icons:
   android: "launcher_icon"
   image_path: "assets/images/iconFG.png"


### PR DESCRIPTION
- improved loading in viewer: now it can be stopped/restarted, shows additional data (speed, time left...), performance changes
- current/total counter in viewer adapts its size to always fit
- image will be reencoded if resolution width is more than 4K, this should fix out of memory crashes if multiple HQ images were loaded
- video zooming
- panning when zoomed now is more responsive and shouldn't falsely trigger swiping away/page change
- share button now has a menu with multiple actions (you can set the default one in settings)
- app now asks if you want to quit if you press "Back" on the main screen

- search box improvements
-- bumped auto suggestions limit to 10 for all servers
-- clear all button
-- don't lose focus after selecting from auto suggestions and don't remove "-" if it was at the start of current tag

- other small fixes
