### PR TITLE
Tag Filters, better page loading...

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -8,6 +8,7 @@
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.VIBRATE"/>
 
 
     <application

--- a/lib/DesktopHome.dart
+++ b/lib/DesktopHome.dart
@@ -65,7 +65,7 @@ class _DesktopHomeState extends State<DesktopHome> {
   }
   void setSearchGlobal(SearchGlobals searchGlobal){
     searchGlobals[globalsIndex] = searchGlobal;
-    searchAction(searchGlobals[globalsIndex].tags!);
+    searchAction(searchGlobals[globalsIndex].tags);
   }
   void searchAction(String text) {
     // Remove extra spaces
@@ -114,10 +114,10 @@ class _DesktopHomeState extends State<DesktopHome> {
             if(searchGlobals.length > 1) {
               if(globalsIndex == searchGlobals.length - 1){
                 globalsIndex --;
-                searchTagsController.text = searchGlobals[globalsIndex].tags!;
+                searchTagsController.text = searchGlobals[globalsIndex].tags;
                 searchGlobals.removeAt(globalsIndex + 1);
               } else {
-                searchTagsController.text = searchGlobals[globalsIndex + 1].tags!;
+                searchTagsController.text = searchGlobals[globalsIndex + 1].tags;
                 searchGlobals.removeAt(globalsIndex);
               }
             } else {
@@ -196,7 +196,7 @@ class _DesktopHomeState extends State<DesktopHome> {
             onPressed: (){
               getPerms();
               // call a function to save the currently viewed image when the save button is pressed
-              if (searchGlobals[globalsIndex].selected!.length > 0){
+              if (searchGlobals[globalsIndex].selected.length > 0){
                 widget.snatchHandler.queue(searchGlobals[globalsIndex].getSelected(), widget.settingsHandler.jsonWrite,searchGlobals[globalsIndex].selectedBooru!.name!,widget.settingsHandler.snatchCooldown);
                 setState(() {
                   searchGlobals[globalsIndex].selected = [];
@@ -216,7 +216,7 @@ class _DesktopHomeState extends State<DesktopHome> {
                 children: [
                   Container(
                     height: MediaQuery.of(context).size.height * 0.65,
-                    child: ImagePreviews(widget.settingsHandler, searchGlobals[globalsIndex], widget.snatchHandler),
+                    child: ImagePreviews(widget.settingsHandler, searchGlobals[globalsIndex], widget.snatchHandler, searchAction),
                     padding: EdgeInsets.all(2),
                     decoration: BoxDecoration(
                       border: Border.all(color: Get.context!.theme.backgroundColor,width: 2),
@@ -258,7 +258,7 @@ class _DesktopTagListenerState extends State<DesktopTagListener> {
     return ValueListenableBuilder(valueListenable: widget.valueNotifier,
         builder: (BuildContext context, BooruItem value, Widget? child){
           return Container(
-              child: TagView(value, widget.searchGlobals),
+              child: TagView(value, widget.searchGlobals, widget.settingsHandler),
               padding: EdgeInsets.all(5),
               decoration: BoxDecoration(
                   border: Border.all(color: Get.context!.theme.accentColor,width: 2),

--- a/lib/SearchGlobals.dart
+++ b/lib/SearchGlobals.dart
@@ -7,7 +7,7 @@ import 'package:get/get.dart';
 
 
 class SearchGlobals{
-  String? tags = "";
+  String tags = "";
   Booru? selectedBooru;
   int pageNum = 0;
   double scrollPosition = 0;
@@ -19,7 +19,7 @@ class SearchGlobals{
   ValueNotifier? displayAppbar = ValueNotifier(true);
   ValueNotifier? viewedIndex = ValueNotifier(0);
   ValueNotifier<BooruItem> currentItem = ValueNotifier(new BooruItem("", "", "", [], "", ""));
-  List? selected = [];
+  List selected = [];
   SearchGlobals(this.selectedBooru,this.tags);
   @override
   String toString() {
@@ -27,8 +27,8 @@ class SearchGlobals{
   }
   List<BooruItem> getSelected(){
     List<BooruItem>? selectedItems = [];
-    for (int i=0; i < selected!.length; i++){
-      selectedItems.add(booruHandler!.fetched!.elementAt(selected![i]));
+    for (int i=0; i < selected.length; i++){
+      selectedItems.add(booruHandler!.fetched.elementAt(selected[i]));
     }
     return selectedItems;
   }

--- a/lib/ServiceHandler.dart
+++ b/lib/ServiceHandler.dart
@@ -63,7 +63,9 @@ class ServiceHandler{
         result = await platform.invokeMethod("getCachePath") + "/";
       } else if (Platform.isLinux){
         result = Platform.environment['HOME']! + "/.loliSnatcher/cache/";
-      }
+      } else if (Platform.isWindows){
+        result = Platform.environment['LOCALAPPDATA']! + "/LoliSnatcher/cache/";
+      } 
     } catch(e){
       print(e);
     }
@@ -107,7 +109,7 @@ class ServiceHandler{
     try{
       if (Platform.isAndroid){
         await platform.invokeMethod("emptyCache");
-      } else if (Platform.isLinux){
+      } else if (Platform.isLinux || Platform.isWindows){
         String cacheD = await getCacheDir();
         File cacheDir = new File(cacheD);
         cacheDir.delete(recursive: true);
@@ -125,10 +127,31 @@ class ServiceHandler{
     }
   }
   static void makeImmersive(){
-    platform.invokeMethod("systemUIMode",{"mode":"immersive"});
+    if (Platform.isAndroid){
+      platform.invokeMethod("systemUIMode",{"mode":"immersive"});
+    }
   }
   static void makeNormal(){
-    platform.invokeMethod("systemUIMode",{"mode":"normal"});
+    if (Platform.isAndroid){
+      platform.invokeMethod("systemUIMode",{"mode":"normal"});
+    }
+  }
+  static void setBrightness(double brightness) {
+    // TODO WIP
+    if (Platform.isAndroid){
+      platform.invokeMethod("setBrightness",{"brightness": brightness});
+    }
+  }
+  static void setVolume(int volume, int showSystemUI) {
+    // TODO WIP
+    if (Platform.isAndroid){
+      platform.invokeMethod("setVolume",{"volume": volume, "showUI": showSystemUI});
+    }
+  }
+  static void setVolumeButtons(bool setActive) {
+    if (Platform.isAndroid){
+      platform.invokeMethod("setVolumeButtons",{"setActive": setActive});
+    }
   }
 
   static void launchURL(String url){
@@ -136,6 +159,8 @@ class ServiceHandler{
       platform.invokeMethod("launchURL", {"url":"$url"});
     } else if (Platform.isLinux) {
       Process.run('xdg-open', [url]);
+    } else if (Platform.isWindows) {
+      /////////////////////
     }
   }
   Future<Uint8List?> makeVidThumb(String videoURL) async {

--- a/lib/SettingsHandler.dart
+++ b/lib/SettingsHandler.dart
@@ -16,8 +16,9 @@ import 'libBooru/DBHandler.dart';
 class SettingsHandler {
   ServiceHandler serviceHandler = new ServiceHandler();
   DBHandler dbHandler = new DBHandler();
-  String defTags = "rating:safe", previewMode = "Sample", videoCacheMode = "Stream", prefBooru = "", cachePath = "", previewDisplay = "Waterfall", galleryMode="Full Res", shareAction = "Ask", appMode = "Mobile";
-  int limit = 20, portraitColumns = 2,landscapeColumns = 4, preloadCount = 2, snatchCooldown = 250;
+  String defTags = "rating:safe", previewMode = "Sample", videoCacheMode = "Stream", prefBooru = "", cachePath = "", previewDisplay = "Waterfall", galleryMode="Full Res", shareAction = "Ask", appMode = "Mobile", galleryBarPosition = 'Top';
+  List<String> hatedTags = [], lovedTags = [];
+  int limit = 20, portraitColumns = 2, landscapeColumns = 4, preloadCount = 2, snatchCooldown = 250;
   int SDKVer = 0;
   String verStr = "1.8.0";
   List<Booru> booruList = [];
@@ -31,7 +32,10 @@ class SettingsHandler {
   ];*/
   String themeMode = "dark";
   String path = "";
-  bool jsonWrite = false, autoPlayEnabled = true, loadingGif = false, imageCache = false, mediaCache = false, autoHideImageBar = false, dbEnabled = true, searchHistoryEnabled = true;
+  bool jsonWrite = false, autoPlayEnabled = true, loadingGif = false,
+        imageCache = false, mediaCache = false, autoHideImageBar = false,
+          dbEnabled = true, searchHistoryEnabled = true, filterHated = false,
+            useVolumeButtonsForScroll = false;
   Future<bool> writeDefaults() async{
     if (path == ""){
       path = await getExtDir();
@@ -51,7 +55,7 @@ class SettingsHandler {
   Future<bool> loadSettings() async{
     if (path == ""){
       path = await getExtDir();
-      print("found path $path");
+      // print("found path $path");
     }
     if (SDKVer == 0){
       SDKVer = await getSDKVer();
@@ -70,37 +74,37 @@ class SettingsHandler {
           case("Default Tags"):
             if (settings[i].split(" = ").length > 1){
               defTags = settings[i].split(" = ")[1];
-              print("Found Default Tags " + settings[i].split(" = ")[1]);
+              // print("Found Default Tags " + settings[i].split(" = ")[1]);
             }
             break;
           case("Limit"):
             if (settings[i].split(" = ").length > 1){
               limit = int.parse(settings[i].split(" = ")[1]);
-              print("Found Limit " + settings[i].split(" = ")[1] );
+              // print("Found Limit " + settings[i].split(" = ")[1] );
             }
             break;
           case("Preview Mode"):
             if (settings[i].split(" = ").length > 1){
               previewMode = settings[i].split(" = ")[1];
-              print("Found Preview Mode " + settings[i].split(" = ")[1] );
+              // print("Found Preview Mode " + settings[i].split(" = ")[1] );
             }
             break;
           case("Portrait Columns"):
             if (settings[i].split(" = ").length > 1){
               portraitColumns = int.parse(settings[i].split(" = ")[1]);
-              print("Found Portrait Columns " + settings[i].split(" = ")[1] );
+              // print("Found Portrait Columns " + settings[i].split(" = ")[1] );
             }
             break;
           case("Landscape Columns"):
             if (settings[i].split(" = ").length > 1){
               landscapeColumns = int.parse(settings[i].split(" = ")[1]);
-              print("Found Landscape Columns " + settings[i].split(" = ")[1] );
+              // print("Found Landscape Columns " + settings[i].split(" = ")[1] );
             }
             break;
           case("Preload Count"):
             if (settings[i].split(" = ").length > 1){
               preloadCount = int.parse(settings[i].split(" = ")[1]);
-              print("Found Preload Count " + settings[i].split(" = ")[1] );
+              // print("Found Preload Count " + settings[i].split(" = ")[1] );
             }
             break;
           case("Write Json"):
@@ -110,7 +114,7 @@ class SettingsHandler {
               } else {
                 jsonWrite = false;
               }
-              print("Found jsonWrite " + settings[i].split(" = ")[1] );
+              // print("Found jsonWrite " + settings[i].split(" = ")[1] );
             }
             break;
           case("Auto Play"):
@@ -120,7 +124,7 @@ class SettingsHandler {
               } else {
                 autoPlayEnabled = false;
               }
-              print("Found Auto Play " + settings[i].split(" = ")[1] );
+              // print("Found Auto Play " + settings[i].split(" = ")[1] );
             }
             break;
           case("Loading Gif"):
@@ -130,7 +134,7 @@ class SettingsHandler {
               } else {
                 loadingGif = false;
               }
-              print("Found Loading gif " + settings[i].split(" = ")[1] );
+              // print("Found Loading gif " + settings[i].split(" = ")[1] );
             }
             break;
           case("Image Cache"):
@@ -140,7 +144,7 @@ class SettingsHandler {
               } else {
                 imageCache = false;
               }
-              print("Found Image Cache " + settings[i].split(" = ")[1] );
+              // print("Found Image Cache " + settings[i].split(" = ")[1] );
             }
             break;
           case("Media Cache"):
@@ -150,19 +154,19 @@ class SettingsHandler {
               } else {
                 mediaCache = false;
               }
-              print("Found Image Cache " + settings[i].split(" = ")[1] );
+              // print("Found Image Cache " + settings[i].split(" = ")[1] );
             }
             break;
           case("Video Cache Mode"):
             if (settings[i].split(" = ").length > 1){
               videoCacheMode = settings[i].split(" = ")[1];
-              print("Found Video Cache Mode " + settings[i].split(" = ")[1] );
+              // print("Found Video Cache Mode " + settings[i].split(" = ")[1] );
             }
             break;
           case("Share Action"):
             if (settings[i].split(" = ").length > 1){
               shareAction = settings[i].split(" = ")[1];
-              print("Found Share Action " + settings[i].split(" = ")[1] );
+              // print("Found Share Action " + settings[i].split(" = ")[1] );
             }
             break;
           case("Pref Booru"):
@@ -171,7 +175,7 @@ class SettingsHandler {
               if(prefBooru.isEmpty){
                 prefBooru = "";
               }
-              print("Found Pref Booru " + settings[i].split(" = ")[1] );
+              // print("Found Pref Booru " + settings[i].split(" = ")[1] );
             }
             break;
           case ("Autohide Bar"):
@@ -181,25 +185,31 @@ class SettingsHandler {
               } else {
                 autoHideImageBar = false;
               }
-              print("Auto hide image bar " + settings[i].split(" = ")[1] );
+              // print("Auto hide image bar " + settings[i].split(" = ")[1] );
             }
             break;
           case("Snatch Cooldown"):
             if (settings[i].split(" = ").length > 1){
               snatchCooldown = int.parse(settings[i].split(" = ")[1]);
-              print("Found Snatch cooldown " + settings[i].split(" = ")[1] );
+              // print("Found Snatch cooldown " + settings[i].split(" = ")[1] );
             }
             break;
           case ("Preview Display"):
             if (settings[i].split(" = ").length > 1){
               previewDisplay = settings[i].split(" = ")[1];
-              print("Found Preview Display Mode " + settings[i].split(" = ")[1] );
+              // print("Found Preview Display Mode " + settings[i].split(" = ")[1] );
             }
             break;
           case ("Gallery Mode"):
             if (settings[i].split(" = ").length > 1){
               galleryMode = settings[i].split(" = ")[1];
-              print("Found Gallery Mode " + settings[i].split(" = ")[1] );
+              // print("Found Gallery Mode " + settings[i].split(" = ")[1] );
+            }
+            break;
+          case ("Gallery Bar Position"):
+            if (settings[i].split(" = ").length > 1){
+              galleryBarPosition = settings[i].split(" = ")[1];
+              // print("Found Gallery Bar Position " + settings[i].split(" = ")[1] );
             }
             break;
           case ("Enable Database"):
@@ -209,7 +219,7 @@ class SettingsHandler {
               } else {
                 dbEnabled = false;
               }
-              print("Found dbEnabled " + settings[i].split(" = ")[1] );
+              // print("Found dbEnabled " + settings[i].split(" = ")[1] );
             }
             break;
           case ("Search History"):
@@ -219,14 +229,47 @@ class SettingsHandler {
               } else {
                 searchHistoryEnabled = false;
               }
-              print("Found searchHistoryEnabled " + settings[i].split(" = ")[1] );
+              // print("Found searchHistoryEnabled " + settings[i].split(" = ")[1] );
             }
             break;
           case ("App Mode"):
             if (settings[i].split(" = ").length > 1){
               appMode = settings[i].split(" = ")[1];
-              print("App mode found " + settings[i].split(" = ")[1] );
+              // print("App mode found " + settings[i].split(" = ")[1] );
             }
+            break;
+          case("Hated Tags"):
+            if (settings[i].split(" = ").length > 1){
+              hatedTags = cleanTagsList(settings[i].split(" = ")[1].split(','));
+              // print("Found Hated Tags " + settings[i].split(" = ")[1]);
+            }
+            break;
+          case ("Filter Hated"):
+            if (settings[i].split(" = ").length > 1){
+              if (settings[i].split(" = ")[1] == "true"){
+                filterHated = true;
+              } else {
+                filterHated = false;
+              }
+              // print("Found filterHated " + settings[i].split(" = ")[1] );
+            }
+            break;
+          case("Loved Tags"):
+            if (settings[i].split(" = ").length > 1){
+              lovedTags = cleanTagsList(settings[i].split(" = ")[1].split(','));
+              // print("Found Loved Tags " + settings[i].split(" = ")[1]);
+            }
+            break;
+          case ("Volume Buttons Scroll"):
+            if (settings[i].split(" = ").length > 1){
+              if (settings[i].split(" = ")[1] == "true"){
+                useVolumeButtonsForScroll = true;
+              } else {
+                useVolumeButtonsForScroll = false;
+              }
+              // print("Found useVolumeButtonsForScroll " + settings[i].split(" = ")[1] );
+            }
+            break;
         }
       }
     }
@@ -249,6 +292,14 @@ class SettingsHandler {
     var writer = settingsFile.openWrite();
     writer.write("Default Tags = $defTags\n");
     this.defTags = defTags;
+    writer.write("Hated Tags = ${cleanTagsList(hatedTags).join(',')}\n");
+    this.hatedTags = hatedTags;
+    writer.write("Filter Hated = $filterHated\n");
+    writer.write("Loved Tags = ${cleanTagsList(lovedTags).join(',')}\n");
+    this.lovedTags = lovedTags;
+
+    writer.write("Volume Buttons Scroll = $useVolumeButtonsForScroll\n");
+
       // Write limit if it between 0-100
     if (limit <= 100 && limit >= 5){
       writer.write("Limit = $limit\n");
@@ -275,12 +326,13 @@ class SettingsHandler {
     writer.write("Snatch Cooldown  = $snatchCooldown\n");
     writer.write("Preview Display = $previewDisplay\n");
     writer.write("Gallery Mode = $galleryMode\n");
+    writer.write("Gallery Bar Position = $galleryBarPosition\n");
     writer.write("Enable Database = $dbEnabled\n");
     writer.write("Search History = $searchHistoryEnabled\n");
     writer.write("App Mode = $appMode\n");
     writer.close();
-    ServiceHandler.displayToast("Settings Saved! \n Some changes may not take effect until the app is restarted");
-    //Get.snackbar("Settings Saved!","Some changes may not take effect until the app is restarted",snackPosition: SnackPosition.TOP,duration: Duration(seconds: 5),colorText: Colors.black, backgroundColor: Get.context!.theme.primaryColor);
+    ServiceHandler.displayToast("Settings Saved!\nSome changes may not take effect until the search is refreshed or the app is restarted");
+    //Get.snackbar("Settings Saved!","Some changes may not take effect until the search is refreshed or the app is restarted",snackPosition: SnackPosition.TOP,duration: Duration(seconds: 5),colorText: Colors.black, backgroundColor: Get.context!.theme.primaryColor);
     return true;
   }
 
@@ -368,12 +420,33 @@ class SettingsHandler {
     return true;
   }
 
+  List<List<String>> parseTagsList(List<String> itemTags, {bool isCapped = true}) {
+    List<String> cleanItemTags = cleanTagsList(itemTags);
+    List<String> hatedInItem = this.hatedTags.where((tag) => cleanItemTags.contains(tag)).toList();
+    List<String> lovedInItem = this.lovedTags.where((tag) => cleanItemTags.contains(tag)).toList();
+
+    if(isCapped && hatedInItem.length > 5) {
+      hatedInItem = [...hatedInItem.take(5), '...'];
+    }
+    if(isCapped && lovedInItem.length > 5) {
+      lovedInItem = [...lovedInItem.take(5), '...'];
+    }
+
+    return [hatedInItem, lovedInItem];
+  }
+
+  List<String> cleanTagsList(List<String> tags) {
+    return tags.where((tag) => tag != "").map((tag) => tag.trim().toLowerCase()).toList();
+  }
+
   Future<String> getExtDir() async{
     String path = "";
     if (Platform.isAndroid){
       path = await serviceHandler.getExtDir() + "/LoliSnatcher/config/";
     } else if (Platform.isLinux){
       path = Platform.environment['HOME']! + "/.loliSnatcher/config/";
+    } else if (Platform.isWindows) {
+      path = Platform.environment['LOCALAPPDATA']! + "/LoliSnatcher/config/";
     }
     return path;
   }
@@ -382,6 +455,10 @@ class SettingsHandler {
       return await serviceHandler.getSDKVersion();
     } else if (Platform.isLinux){
       return 1;
+    } else if (Platform.isWindows) {
+      return 2;
+    } else {
+      return -1;
     }
   }
   Future getDocumentsDir() async{
@@ -389,6 +466,8 @@ class SettingsHandler {
       return await serviceHandler.getDocumentsDir() + "/LoliSnatcher/config/";
     } else if (Platform.isLinux){
       return Platform.environment['HOME']! + "/.loliSnatcher/config/";
+    } else if (Platform.isWindows) {
+      path = Platform.environment['LOCALAPPDATA']! + "/LoliSnatcher/config/";
     }
   }
   Future<bool> initialize() async{

--- a/lib/SnatchHandler.dart
+++ b/lib/SnatchHandler.dart
@@ -67,10 +67,10 @@ class SnatchHandler {
         booruNameList!.add(booruName);
         queuedItems!.value ++;
         if (booruItems.length > 1){
-          ServiceHandler.displayToast("Items added to snatch queue\n Amount: ${booruItems.length}\n Queue Position: ${queuedItems!.value}");
+          ServiceHandler.displayToast("Items added to snatch queue\nAmount: ${booruItems.length}\nQueue Position: ${queuedItems!.value}");
           //Get.snackbar("Items added to snatch queue", "Amount: ${booruItems.length}\n Queue Position: ${queuedItems.value}", snackPosition: SnackPosition.BOTTOM, duration: Duration(seconds: 2), colorText: Colors.black, backgroundColor: Get.context!.theme.primaryColor);
         } else {
-          ServiceHandler.displayToast("Item added to snatch queue\n ${booruItems[0].fileURL} \n Queue Position: ${queuedItems!.value}");
+          ServiceHandler.displayToast("Item added to snatch queue\nQueue Position: ${queuedItems!.value}");
           //Get.snackbar("Item added to snatch queue", booruItems[0].fileURL + "\n Queue Position: ${queuedItems.value}", snackPosition: SnackPosition.BOTTOM, duration: Duration(seconds: 2), colorText: Colors.black, backgroundColor: Get.context!.theme.primaryColor);
         }
       }
@@ -87,7 +87,7 @@ class SnatchHandler {
     List temp = new BooruHandlerFactory().getBooruHandler(booru, limit, settingsHandler!.dbHandler);
     booruHandler = temp[0];
     page = temp[1];
-    ServiceHandler.displayToast("Snatching Images \n Do not close the app!");
+    ServiceHandler.displayToast("Snatching Images\nDo not close the app!");
     //Get.snackbar("Snatching Images","Do not close the app!",snackPosition: SnackPosition.TOP,duration: Duration(seconds: 5),colorText: Colors.black, backgroundColor: Get.context!.theme.primaryColor);
     while (count < int.parse(amount) && !booruHandler.locked){
       booruItems = await booruHandler.Search(tags,page);

--- a/lib/Tools.dart
+++ b/lib/Tools.dart
@@ -10,10 +10,25 @@ class Tools {
         ' ' +
         suffixes[i];
   }
+
   static int boolToInt(bool boolean){
     return boolean ? 1 : 0;
   }
   static bool intToBool(int boolean){
     return boolean != 0 ? true : false;
+  }
+
+  static String getFileExt(fileURL){
+    int queryLastIndex = fileURL.lastIndexOf("?"); // if has GET query parameters
+    int lastIndex = queryLastIndex != -1 ? queryLastIndex : fileURL.length;
+    String fileExt = fileURL.substring(fileURL.lastIndexOf(".") + 1, lastIndex);
+    return fileExt;
+  }
+
+  static String getFileName(fileURL){
+    int queryLastIndex = fileURL.lastIndexOf("?"); // if has GET query parameters
+    int lastIndex = queryLastIndex != -1 ? queryLastIndex : fileURL.length;
+    String fileExt = fileURL.substring(fileURL.lastIndexOf("/") + 1, lastIndex);
+    return fileExt;
   }
 }

--- a/lib/ViewUtils.dart
+++ b/lib/ViewUtils.dart
@@ -10,15 +10,15 @@ import 'package:LoliSnatcher/widgets/CachedThumb.dart';
 
 class ViewUtils {
 
-  static List<dynamic> getFileTypeAndIcon(String fileExt) {
-    if (['jpg', 'jpeg', 'png'].any((val) => fileExt.contains(val))) {
-      return ['image', Icons.photo];
-    } else if (['webm', 'mp4'].any((val) => fileExt.contains(val))) {
-      return ['video', CupertinoIcons.videocam_fill];
-    } else if (['gif'].any((val) => fileExt.contains(val))) {
-      return ['gif', CupertinoIcons.play_fill];
+  static IconData getFileIcon(String? mediaType) {
+    if (mediaType == 'image') {
+      return Icons.photo;
+    } else if (mediaType == 'video') {
+      return CupertinoIcons.videocam_fill;
+    } else if (mediaType == 'animation') {
+      return CupertinoIcons.play_fill;
     } else {
-      return ['other', CupertinoIcons.question];
+      return CupertinoIcons.question;
     }
   }
 
@@ -27,50 +27,62 @@ class ViewUtils {
   *
   */
   static Widget sampleorThumb(BooruItem item, int columnCount, SettingsHandler settingsHandler) {
-    List<dynamic>? itemType = getFileTypeAndIcon(item.fileExt);
-    bool isThumb = settingsHandler.previewMode == "Thumbnail" ||
-        (itemType[0] == 'gif' || itemType[0] == 'video');
+    IconData itemIcon = getFileIcon(item.mediaType);
+    bool isThumb = settingsHandler.previewMode == "Thumbnail" || (item.mediaType == 'animation' || item.mediaType == 'video'); // item.mediaType == 'animation'; 
     String? thumbURL = isThumb ? item.thumbnailURL : item.sampleURL;
-    return Stack(alignment: settingsHandler.previewDisplay == "Waterfall" ? Alignment.center : Alignment.bottomCenter, children: [
-      CachedThumb(thumbURL, item.mediaType!, settingsHandler, columnCount),
-      Container(
-        alignment: Alignment.bottomRight,
-        child: Container(
-          padding: EdgeInsets.all(2),
-          decoration: BoxDecoration(
-            color: Colors.black,
-            // borderRadius: BorderRadius.circular(100)
-          ),
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              item.isFavourite ?
-              Icon(
-                Icons.favorite,
-                color: Colors.red,
-                size: 14,
-              ) : Container(width: 0,height: 0,),
-              item.isSnatched ?
-              Icon(
-                Icons.save_alt,
-                color: Colors.white,
-                size: 14,
-              ) : Container(width: 0,height: 0,),
-              Icon(
-                itemType[1],
-                color: Colors.white,
-                size: 14,
+
+    List<List<String>> parsedTags = settingsHandler.parseTagsList(item.tagsList, isCapped: false);
+    bool isHated = parsedTags[0].length > 0;
+    bool isLoved = parsedTags[1].length > 0;
+
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(3),
+      child: Stack(
+        alignment: settingsHandler.previewDisplay == "Waterfall" ? Alignment.center : Alignment.bottomCenter,
+        children: [
+          CachedThumb(thumbURL, item.mediaType!, settingsHandler, columnCount, isHated),
+          Container(
+            alignment: Alignment.bottomRight,
+            child: Container(
+              padding: EdgeInsets.all(2),
+              decoration: BoxDecoration(
+                color: Colors.black,
+                // borderRadius: BorderRadius.circular(100)
               ),
-            ],
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  if(item.isFavourite || isLoved)
+                    Icon(
+                      item.isFavourite ? Icons.favorite : Icons.star,
+                      color: item.isFavourite ? Colors.red : Colors.grey,
+                      size: 14,
+                    ),
+
+                  if(item.isSnatched)
+                    Icon(
+                      Icons.save_alt,
+                      color: Colors.white,
+                      size: 14,
+                    ),
+
+                  Icon(
+                    itemIcon,
+                    color: Colors.white,
+                    size: 14,
+                  ),
+                ],
+              ),
+            ),
           ),
-        ),
-      ),
-    ]);
+        ]
+      )
+    );
   }
 
   static void jumpToItem(int item, SearchGlobals searchGlobals, ScrollController gridController, SettingsHandler settingsHandler, BuildContext context) {
-    int? totalItems = searchGlobals.booruHandler!.fetched!.length;
-    print("jump to item called index is: $item");
+    int? totalItems = searchGlobals.booruHandler!.fetched.length;
+    // print("jump to item called index is: $item");
     if (totalItems > 0) {
       double viewportHeight = gridController.position.viewportDimension;
       double totalHeight = gridController.position.maxScrollExtent + viewportHeight;

--- a/lib/libBooru/BooruHandler.dart
+++ b/lib/libBooru/BooruHandler.dart
@@ -2,30 +2,34 @@ import 'Booru.dart';
 import 'BooruItem.dart';
 import 'DBHandler.dart';
 abstract class BooruHandler {
-  int? pageNum;
+  // pagenum = -1 as "didn't load anything yet" state
+  // gets set to higher number for special cases in handler factory
+  int pageNum = -1; 
   int limit = 20;
   String prevTags = "";
   bool locked = false;
   Booru booru;
   String verStr = "1.8.0";
-  List<BooruItem>? fetched;
+  List<BooruItem> fetched = [];
   bool tagSearchEnabled = true;
+  bool hasSizeData = false;
   bool isActive = false;
   DBHandler? dbHandler;
   BooruHandler(this.booru,this.limit);
   Future? Search(String tags, int pageNum){}
   String? makeURL(String tags){}
-  String getFileExt(fileURL){
-    return fileURL.substring(fileURL.lastIndexOf(".") + 1);
-  }
   tagSearch(String input) {}
+
+  String getDescription() {
+    return '';
+  }
 
   //set the isSnatched and isFavourite booleans for a BooruItem in fetched
   Future setTrackedValues(int fetchedIndex) async{
     if (dbHandler!.db != null){
-      List<bool> values = await dbHandler!.getTrackedValues(fetched![fetchedIndex].fileURL);
-      fetched![fetchedIndex].isSnatched = values[0];
-      fetched![fetchedIndex].isFavourite = values[1];
+      List<bool> values = await dbHandler!.getTrackedValues(fetched[fetchedIndex].fileURL);
+      fetched[fetchedIndex].isSnatched = values[0];
+      fetched[fetchedIndex].isFavourite = values[1];
     }
   }
 }

--- a/lib/libBooru/BooruHandlerFactory.dart
+++ b/lib/libBooru/BooruHandlerFactory.dart
@@ -17,37 +17,37 @@ import 'SzurubooruHandler.dart';
 import 'e621Handler.dart';
 class BooruHandlerFactory{
   BooruHandler? booruHandler;
-  int pageNum = 0;
+  int pageNum = -1;
   List getBooruHandler(Booru booru, int limit, DBHandler? dbHandler){
     switch (booru.type) {
       case("Moebooru"):
-        pageNum = 1;
+        pageNum = 0;
         booruHandler = new MoebooruHandler(booru, limit);
         break;
       case("Gelbooru"):
         booruHandler = new GelbooruHandler(booru, limit);
         break;
       case("Danbooru"):
-        pageNum = 1;
+        pageNum = 0;
         booruHandler = new DanbooruHandler(booru, limit);
         break;
       case("e621"):
-        pageNum = 1;
+        pageNum = 0;
         booruHandler = new e621Handler(booru, limit);
         break;
       case("Shimmie"):
-        pageNum = 1;
+        pageNum = 0;
         booruHandler = new ShimmieHandler(booru, limit);
         break;
       case("Philomena"):
-        pageNum = 1;
+        pageNum = 0;
         booruHandler = new PhilomenaHandler(booru, limit);
         break;
       case("Szurubooru"):
         booruHandler = new SzurubooruHandler(booru, limit);
         break;
       case("Sankaku"):
-        pageNum = 1;
+        pageNum = 0;
         booruHandler = new SankakuHandler(booru, limit);
         break;
       case("Hydrus"):
@@ -57,7 +57,7 @@ class BooruHandlerFactory{
         booruHandler = new GelbooruV1Handler(booru, limit);
         break;
       case("BooruOnRails"):
-        pageNum = 1;
+        pageNum = 0;
         booruHandler = new BooruOnRailsHandler(booru, limit);
         break;
       case("Favourites"):
@@ -65,6 +65,6 @@ class BooruHandlerFactory{
         break;
     }
     booruHandler!.dbHandler = dbHandler;
-    return [booruHandler,pageNum];
+    return [booruHandler, pageNum];
   }
 }

--- a/lib/libBooru/BooruItem.dart
+++ b/lib/libBooru/BooruItem.dart
@@ -1,24 +1,29 @@
 class BooruItem{
-  String fileURL,sampleURL,thumbnailURL,postURL,fileExt;
-  List? tagsList;
+  String fileURL, sampleURL, thumbnailURL, postURL, fileExt;
+  List<String> tagsList;
   String? mediaType;
   bool isSnatched = false, isFavourite = false;
   String idOnHost = "";
-  BooruItem(this.fileURL,this.sampleURL,this.thumbnailURL,this.tagsList,this.postURL,this.fileExt){
+  double? fileWidth, fileHeight;
+  BooruItem(this.fileURL,this.sampleURL,this.thumbnailURL,this.tagsList,this.postURL,this.fileExt, {this.fileWidth, this.fileHeight}){
     if (this.sampleURL.isEmpty || this.sampleURL == "null"){
       this.sampleURL = this.thumbnailURL;
     }
     this.fileExt = this.fileExt.toLowerCase();
-    if (this.fileExt == "webm" || this.fileExt == "mp4"){
-      this.mediaType = "video";
-    } else {
+    if (["jpg", "jpeg", "png"].any((val) => this.fileExt == val)) {
       this.mediaType = "image";
+    } else if (["webm", "mp4"].any((val) => this.fileExt == val)) {
+      this.mediaType = "video";
+    } else if (this.fileExt == "gif") {
+      this.mediaType = "animation";
+    } else {
+      this.mediaType = "other";
     }
   }
-  bool isVideo(){
+  bool isVideo() {
     return (this.mediaType == "video");
   }
-  toJSON(){
+  toJSON() {
     return {'postURL': "$postURL",'fileURL': "$fileURL", 'sampleURL': "$sampleURL", 'thumbnailURL': "$thumbnailURL", 'tags': tagsList, 'fileExt': fileExt};
   }
 }

--- a/lib/libBooru/BooruOnRailsHandler.dart
+++ b/lib/libBooru/BooruOnRailsHandler.dart
@@ -1,18 +1,18 @@
 import 'dart:convert';
-import 'package:LoliSnatcher/libBooru/PhilomenaHandler.dart';
-import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
 import 'dart:async';
 import 'Booru.dart';
 import 'BooruHandler.dart';
 import 'BooruItem.dart';
+import 'package:LoliSnatcher/Tools.dart';
 
 class BooruOnRailsHandler extends BooruHandler {
   bool tagSearchEnabled = true;
-  List<BooruItem>? fetched = [];
+  List<BooruItem> fetched = [];
+
   BooruOnRailsHandler(Booru booru,int limit) : super(booru,limit);
   Future Search(String tags,int pageNum) async{
-    int length = fetched!.length;
+    int length = fetched.length;
     if (tags == "" || tags == " "){
       tags = "*";
     }
@@ -44,22 +44,30 @@ class BooruOnRailsHandler extends BooruHandler {
           }
           if (current['representations']['full'] != null && current['representations']['medium'] != null && current['representations']['thumb_small'] != null) {
             String sampleURL = current['representations']['medium'], thumbURL = current['representations']['thumb_small'];
-            if(current["mime_type"].toString().contains("video")){
-              String tmpURL = sampleURL.substring(0,sampleURL.lastIndexOf("/")+1) + "thumb.gif";
+            if(current["mime_type"].toString().contains("video")) {
+              String tmpURL = sampleURL.substring(0, sampleURL.lastIndexOf("/") + 1) + "thumb.gif";
               sampleURL = tmpURL;
               thumbURL = tmpURL;
-              print("tmpurl is" + tmpURL);
+              print("tmpurl is " + tmpURL);
             }
-            fetched!.add(new BooruItem(current['representations']['full'],sampleURL,thumbURL,currentTags,makePostURL(current['id'].toString()),getFileExt(current['representations']['full'])));
+            
+            fetched.add(BooruItem(
+              current['representations']['full'],
+              sampleURL,
+              thumbURL,
+              currentTags,
+              makePostURL(current['id'].toString()),
+              Tools.getFileExt(current['representations']['full'])
+            ));
             if(dbHandler!.db != null){
-              setTrackedValues(fetched!.length - 1);
+              setTrackedValues(fetched.length - 1);
             }
           } else {
             print("post $i skipped");
           }
         }
         prevTags = tags;
-        if (fetched!.length == length){locked = true;}
+        if (fetched.length == length){locked = true;}
         return fetched;
       }
     } catch(e) {

--- a/lib/libBooru/DanbooruHandler.dart
+++ b/lib/libBooru/DanbooruHandler.dart
@@ -5,12 +5,11 @@ import 'BooruHandler.dart';
 import 'BooruItem.dart';
 import 'Booru.dart';
 import 'dart:convert';
+import 'package:LoliSnatcher/Tools.dart';
 /**
  * Booru Handler for the Danbooru engine
  */
 class DanbooruHandler extends BooruHandler{
-  List<BooruItem>? fetched = [];
-
   // Dart constructors are weird so it has to call super with the args
   DanbooruHandler(Booru booru,int limit) : super(booru,limit);
 
@@ -20,7 +19,8 @@ class DanbooruHandler extends BooruHandler{
    */
   Future Search(String tags, int pageNum) async{
     isActive = true;
-    int length = fetched!.length;
+    hasSizeData = true;
+    int length = fetched.length;
     if(this.pageNum == pageNum){
       return fetched;
     }
@@ -44,32 +44,23 @@ class DanbooruHandler extends BooruHandler{
            * to go with the rest of the data so cannot be displayed and are pointless for the app
            */
           if ((current.findElements("file-url").length > 0)) {
-            fetched!.add(new BooruItem(current
-                .findElements("file-url")
-                .elementAt(0)
-                .text, current
-                .findElements("large-file-url")
-                .elementAt(0)
-                .text, current
-                .findElements("preview-file-url")
-                .elementAt(0)
-                .text, current
-                .findElements("tag-string")
-                .elementAt(0).text.split(" ")
-                , makePostURL(current
-                .findElements("id")
-                .elementAt(0)
-                .text),getFileExt(current
-                    .findElements("file-url")
-                    .elementAt(0)
-                    .text)));
+            fetched.add(new BooruItem(
+              current.findElements("file-url").elementAt(0).text,
+              current.findElements("large-file-url").elementAt(0).text,
+              current.findElements("preview-file-url").elementAt(0).text,
+              current.findElements("tag-string").elementAt(0).text.split(" "),
+              makePostURL(current.findElements("id").elementAt(0).text),
+              Tools.getFileExt(current.findElements("file-url").elementAt(0).text),
+              fileHeight: double.tryParse(current.findElements("image-height").elementAt(0).text) ?? null,
+              fileWidth: double.tryParse(current.findElements("image-width").elementAt(0).text) ?? null,
+            ));
             if(dbHandler!.db != null){
-              setTrackedValues(fetched!.length - 1);
+              setTrackedValues(fetched.length - 1);
             }
           }
         }
         prevTags = tags;
-        if (fetched!.length == length){locked = true;}
+        if (fetched.length == length){locked = true;}
         isActive = false;
         return fetched;
       }

--- a/lib/libBooru/FavouritesHandler.dart
+++ b/lib/libBooru/FavouritesHandler.dart
@@ -5,7 +5,6 @@ import 'BooruHandler.dart';
 import 'BooruItem.dart';
 
 class FavouritesHandler extends BooruHandler{
-  List<BooruItem>? fetched = [];
   DBHandler? dbHandler;
   FavouritesHandler(Booru booru,int limit): super(booru,limit){
     print("new favourites handler");
@@ -14,7 +13,7 @@ class FavouritesHandler extends BooruHandler{
 
   Future Search(String tags, int pageNum) async{
     isActive = true;
-    int length = fetched!.length;
+    int length = fetched.length;
     if(this.pageNum == pageNum){
       return fetched;
     }
@@ -22,14 +21,14 @@ class FavouritesHandler extends BooruHandler{
     if (prevTags != tags){
       fetched = [];
     }
-    fetched!.addAll(await dbHandler!.searchDB(tags,fetched!.length.toString(),limit.toString()));
+    fetched.addAll(await dbHandler!.searchDB(tags, fetched.length.toString(), limit.toString()));
     print("dbhandler fetched length is $length");
     prevTags = tags;
-    if (fetched!.isEmpty){
+    if (fetched.isEmpty){
       print("dbhandler dbLocked");
       locked = true;
     } else {
-      if (fetched!.length == length){
+      if (fetched.length == length){
         print("dbhandler dbLocked");
         locked = true;
       }

--- a/lib/libBooru/GelbooruV1Handler.dart
+++ b/lib/libBooru/GelbooruV1Handler.dart
@@ -4,12 +4,12 @@ import 'dart:async';
 import 'BooruHandler.dart';
 import 'BooruItem.dart';
 import 'Booru.dart';
+import 'package:LoliSnatcher/Tools.dart';
 
 /**
  * Booru Handler for the gelbooru engine
  */
 class GelbooruV1Handler extends BooruHandler{
-  List<BooruItem>? fetched = [];
   // Dart constructors are weird so it has to call super with the args
   GelbooruV1Handler(Booru booru,int limit): super(booru,limit);
   bool tagSearchEnabled = false;
@@ -32,9 +32,9 @@ class GelbooruV1Handler extends BooruHandler{
     String url = makeURL(tags);
     print(url);
     try {
-      int length = fetched!.length;
+      int length = fetched.length;
       Uri uri = Uri.parse(url);
-      final response = await http.get(uri,headers: {"Accept": "text/html,application/xml", "user-agent":"Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:83.0) Gecko/20100101 Firefox/83.0"});
+      final response = await http.get(uri, headers: {"Accept": "text/html,application/xml", "user-agent":"Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:83.0) Gecko/20100101 Firefox/83.0"});
       // 200 is the success http response code
       if (response.statusCode == 200) {
         var document = parse(response.body);
@@ -48,15 +48,15 @@ class GelbooruV1Handler extends BooruHandler{
               /**
                * Add a new booruitem to the list .getAttribute will get the data assigned to a particular tag in the xml object
                */
-              fetched!.add(new BooruItem(fileURL,fileURL,thumbURL,tags,makePostURL(id),getFileExt(fileURL)));
+              fetched.add(BooruItem(fileURL, fileURL, thumbURL, tags, makePostURL(id), Tools.getFileExt(fileURL)));
               if(dbHandler!.db != null){
-                setTrackedValues(fetched!.length - 1);
+                setTrackedValues(fetched.length - 1);
               }
             }
           }
         // Create a BooruItem for each post in the list
         prevTags = tags;
-        if (fetched!.length == length){locked = true;}
+        if (fetched.length == length){locked = true;}
         isActive = false;
         return fetched;
       }
@@ -73,6 +73,6 @@ class GelbooruV1Handler extends BooruHandler{
     }
     // This will create a url for the http request
     String makeURL(String tags){
-      return "${booru.baseURL}/index.php?page=post&s=list&tags=${tags.replaceAll(" ", "+")}&pid=${(pageNum! * 20).toString()}";
+      return "${booru.baseURL}/index.php?page=post&s=list&tags=${tags.replaceAll(" ", "+")}&pid=${(pageNum * 20).toString()}";
     }
 }

--- a/lib/libBooru/HydrusHandler.dart
+++ b/lib/libBooru/HydrusHandler.dart
@@ -13,7 +13,6 @@ import 'Booru.dart';
  * Booru Handler for the gelbooru engine
  */
 class HydrusHandler extends BooruHandler{
-  List<BooruItem>? fetched = [];
   bool tagSearchEnabled = false;
   var _fileIDs;
   // Dart constructors are weird so it has to call super with the args
@@ -102,9 +101,16 @@ class HydrusHandler extends BooruHandler{
                   }
                 }
                 if (parsedResponse['metadata'][i]['file_id'] != null){
-                  fetched!.add(new BooruItem("${booru.baseURL}/get_files/file?file_id=${parsedResponse['metadata'][i]['file_id']}&Hydrus-Client-API-Access-Key=${booru.apiKey}", "${booru.baseURL}/get_files/thumbnail?file_id=${parsedResponse['metadata'][i]['file_id']}&Hydrus-Client-API-Access-Key=${booru.apiKey}", "${booru.baseURL}/get_files/thumbnail?file_id=${parsedResponse['metadata'][i]['file_id']}&Hydrus-Client-API-Access-Key=${booru.apiKey}", tagList, "postURL", parsedResponse['metadata'][i]['ext'].toString().substring(1)));
+                  fetched.add(BooruItem(
+                    "${booru.baseURL}/get_files/file?file_id=${parsedResponse['metadata'][i]['file_id']}&Hydrus-Client-API-Access-Key=${booru.apiKey}",
+                    "${booru.baseURL}/get_files/thumbnail?file_id=${parsedResponse['metadata'][i]['file_id']}&Hydrus-Client-API-Access-Key=${booru.apiKey}",
+                    "${booru.baseURL}/get_files/thumbnail?file_id=${parsedResponse['metadata'][i]['file_id']}&Hydrus-Client-API-Access-Key=${booru.apiKey}",
+                    tagList,
+                    "postURL",
+                    parsedResponse['metadata'][i]['ext'].toString().substring(1)
+                  ));
                   if(dbHandler!.db != null){
-                    setTrackedValues(fetched!.length - 1);
+                    setTrackedValues(fetched.length - 1);
                   }
                 }
             }

--- a/lib/libBooru/PhilomenaHandler.dart
+++ b/lib/libBooru/PhilomenaHandler.dart
@@ -1,13 +1,12 @@
 import 'dart:convert';
-import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
 import 'dart:async';
 import 'Booru.dart';
 import 'BooruHandler.dart';
 import 'BooruItem.dart';
+import 'package:LoliSnatcher/Tools.dart';
 
 class PhilomenaHandler extends BooruHandler{
-  List<BooruItem>? fetched = [];
   PhilomenaHandler(Booru booru,int limit) : super(booru,limit);
 
   /**
@@ -16,7 +15,7 @@ class PhilomenaHandler extends BooruHandler{
    */
   Future Search(String tags,int pageNum) async{
     isActive = true;
-    int length = fetched!.length;
+    int length = fetched.length;
     if (tags == "" || tags == " "){
       tags = "*";
     }
@@ -41,20 +40,28 @@ class PhilomenaHandler extends BooruHandler{
           var current = parsedResponse['images'][i];
           if (current['representations']['full'] != null){
             String sampleURL = current['representations']['medium'], thumbURL = current['representations']['thumb_small'];
-            if(current["mime_type"].toString().contains("video")){
-              String tmpURL = sampleURL.substring(0,sampleURL.lastIndexOf("/")+1) + "thumb.gif";
+            if(current["mime_type"].toString().contains("video")) {
+              String tmpURL = sampleURL.substring(0, sampleURL.lastIndexOf("/") + 1) + "thumb.gif";
               sampleURL = tmpURL;
               thumbURL = tmpURL;
-              print("tmpurl is" + tmpURL);
+              print("tmpurl is " + tmpURL);
             }
-            fetched!.add(new BooruItem(current['representations']['full'],sampleURL,thumbURL,current['tags'],makePostURL(current['id'].toString()),getFileExt(current['representations']['full'])));
+
+            fetched.add(BooruItem(
+              current['representations']['full'],
+              sampleURL,
+              thumbURL,
+              current['tags'],
+              makePostURL(current['id'].toString()),
+              Tools.getFileExt(current['representations']['full'])
+            ));
             if(dbHandler!.db != null){
-              setTrackedValues(fetched!.length - 1);
+              setTrackedValues(fetched.length - 1);
             }
           }
         }
         prevTags = tags;
-        if (fetched!.length == length){locked = true;}
+        if (fetched.length == length){locked = true;}
         isActive = false;
         return fetched;
       }

--- a/lib/libBooru/SankakuHandler.dart
+++ b/lib/libBooru/SankakuHandler.dart
@@ -7,7 +7,6 @@ import 'BooruHandler.dart';
 import 'BooruItem.dart';
 
 class SankakuHandler extends BooruHandler{
-  List<BooruItem>? fetched = [];
   SankakuHandler(Booru booru,int limit) : super(booru,limit);
   bool tagSearchEnabled = true;
   String authToken = '';
@@ -18,7 +17,8 @@ class SankakuHandler extends BooruHandler{
    */
   Future Search(String tags,int pageNum) async{
     isActive = true;
-    int length = fetched!.length;
+    hasSizeData = true;
+    int length = fetched.length;
     if(this.pageNum == pageNum){
       return fetched;
     }
@@ -60,18 +60,24 @@ class SankakuHandler extends BooruHandler{
           }
           if (current['file_url'] != null) {
             String fileExt = current['file_type'].split('/')[1]; // image/jpeg
-            fetched!.add(new BooruItem(
-                current['file_url'], current['sample_url'],
-                current['preview_url'], tags,
-                makePostURL(current['id'].toString()), fileExt));
+            fetched.add(BooruItem(
+              current['file_url'],
+              current['sample_url'],
+              current['preview_url'],
+              tags,
+              makePostURL(current['id'].toString()),
+              fileExt,
+              fileWidth: current['width'].toDouble(),
+              fileHeight: current['height'].toDouble(),
+            ));
             if (dbHandler!.db != null) {
-              setTrackedValues(fetched!.length - 1);
+              setTrackedValues(fetched.length - 1);
             }
-            print(fetched![fetched!.length - 1].toString());
+            print(fetched[fetched.length - 1].toString());
           }
         }
         prevTags = tags;
-        if (fetched!.length == length){locked = true;}
+        if (fetched.length == length){locked = true;}
         isActive = false;
         return fetched;
       } else {

--- a/lib/pages/SettingsPage.dart
+++ b/lib/pages/SettingsPage.dart
@@ -3,6 +3,7 @@ import 'package:LoliSnatcher/pages/settings/BooruPage.dart';
 import 'package:LoliSnatcher/pages/settings/DatabasePage.dart';
 import 'package:LoliSnatcher/pages/settings/GalleryPage.dart';
 import 'package:LoliSnatcher/pages/settings/UserInterfacePage.dart';
+import 'package:LoliSnatcher/pages/settings/FilterTagsPage.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/painting.dart';
 import '../SettingsHandler.dart';
@@ -114,6 +115,21 @@ class _SettingsPageState extends State<SettingsPage> {
                     Get.to(() => BehaviourPage(widget.settingsHandler));
                   },
                   child: Text("Behaviour", style: TextStyle(color: Colors.white)),
+                ),
+              ),
+              Container(
+                margin: EdgeInsets.fromLTRB(10,10,10,10),
+                child: TextButton(
+                  style: TextButton.styleFrom(
+                    shape: RoundedRectangleBorder(
+                      borderRadius: new BorderRadius.circular(20),
+                      side: BorderSide(color: Get.context!.theme.accentColor),
+                    ),
+                  ),
+                  onPressed: (){
+                    Get.to(() => FiltersEdit(widget.settingsHandler));
+                  },
+                  child: Text("Tag Filters", style: TextStyle(color: Colors.white)),
                 ),
               ),
               Container(

--- a/lib/pages/settings/DatabasePage.dart
+++ b/lib/pages/settings/DatabasePage.dart
@@ -93,9 +93,9 @@ class _DatabasePageState extends State<DatabasePage> {
                               "Search History",
                               [
                                 Text("Requires enabled Database."),
-                                Text("Records last 200 search queries."),
+                                Text("Records last 500 search queries."),
                                 Text("Long press any history entry for additional actions (Delete, Set as Favourite...)"),
-                                Text("Favourited entries are pinned to the top of the list and will not be included in 200 limit."),
+                                Text("Favourited entries are pinned to the top of the list and will not be included in 500 limit."),
                               ],
                               CrossAxisAlignment.start,
                             )

--- a/lib/pages/settings/FilterTagsPage.dart
+++ b/lib/pages/settings/FilterTagsPage.dart
@@ -1,0 +1,262 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+import 'package:LoliSnatcher/SettingsHandler.dart';
+import 'package:LoliSnatcher/ServiceHandler.dart';
+import 'package:LoliSnatcher/widgets/InfoDialog.dart';
+import 'package:LoliSnatcher/widgets/ScrollingText.dart';
+
+class FiltersEdit extends StatefulWidget {
+  SettingsHandler settingsHandler;
+  FiltersEdit(this.settingsHandler);
+
+  @override
+  _FiltersEditState createState() => _FiltersEditState();
+}
+
+class _FiltersEditState extends State<FiltersEdit> {
+  TextEditingController newTagController = TextEditingController();
+  List<String> hatedList = [];
+  List<String> lovedList = [];
+  bool filterHated = false;
+
+  @override
+  void initState() {
+    hatedList = widget.settingsHandler.hatedTags;
+    lovedList = widget.settingsHandler.lovedTags;
+    filterHated = widget.settingsHandler.filterHated;
+    super.initState();
+  }
+
+  Future<bool> _onWillPop() async {
+    widget.settingsHandler.hatedTags = widget.settingsHandler.cleanTagsList(hatedList);
+    widget.settingsHandler.lovedTags = widget.settingsHandler.cleanTagsList(lovedList);
+    widget.settingsHandler.filterHated = filterHated;
+    bool result = await widget.settingsHandler.saveSettings();
+    return result;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return WillPopScope(
+      onWillPop: _onWillPop,
+      child: Scaffold(
+        resizeToAvoidBottomInset: false,
+        appBar: AppBar(
+            title: Text("Filters Editor"),
+          actions: [
+          ],
+        ),
+        body: Center(
+          child: ListView(
+            children: <Widget>[
+              editableTagsList('Hated'),
+              Container(
+                  margin: EdgeInsets.fromLTRB(10, 2, 10, 2),
+                  child: Row(children: [
+                    Text("Remove Items with Hated Tags: "),
+                    Checkbox(
+                      value: filterHated,
+                      onChanged: (newValue) {
+                        setState(() {
+                          filterHated = newValue!;
+                        });
+                      },
+                      activeColor: Get.context!.theme.primaryColor,
+                    )
+                  ],)
+              ),
+              editableTagsList('Loved'),
+            ],
+          ),
+        ),
+      )
+    );
+  }
+
+
+
+  Widget editableTagsList(type) {
+    List<String> tagsList = getTagsList(type);
+
+    return Column(children: [
+      const SizedBox(height: 10),
+      TextButton.icon(
+        onPressed: null,
+        icon: Icon(type == 'Hated' ? CupertinoIcons.eye_slash : Icons.star, color: type == 'Hated' ? Colors.red : Colors.yellow),
+        label: Text('$type Tags:', style: TextStyle(fontSize: 22, color: Colors.white)),
+      ),
+      ClipRRect(
+        borderRadius: BorderRadius.circular(10),
+        child: Container(
+          height: 200,
+          child: Material(
+            color: Get.context!.theme.dialogBackgroundColor.withOpacity(0.5),
+            child: ListView.builder(
+              padding: EdgeInsets.fromLTRB(10, 5, 10, 5),
+              shrinkWrap: true,
+              itemCount: tagsList.length + 1,
+              scrollDirection: Axis.vertical,
+              itemBuilder: (BuildContext context, int index) {
+                bool isAddButton = index == (tagsList.length);
+                String currentEntry = isAddButton ? '[Add]' : tagsList[index];
+
+                Widget entryRow = TextButton.icon(
+                  style: TextButton.styleFrom(
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(5),
+                      side: BorderSide(color: Get.context!.theme.accentColor),
+                    ),
+                  ),
+                  onPressed: null,
+                  icon: isAddButton ? Icon(Icons.add) : Icon(CupertinoIcons.tag),
+                  label: Expanded(child: ScrollingText(currentEntry, 25, "infiniteWithPause", Colors.white)),
+                );
+
+                return Row(children: <Widget>[
+                  Expanded(
+                    child: GestureDetector(
+                      onTap: () {
+                        if(!isAddButton) newTagController.text = currentEntry;
+                        else newTagController.text = '';
+                        showFilterEntryActions(entryRow, currentEntry, index, type);
+                      },
+                      child: entryRow
+                    )
+                  ),
+                ]);
+              }
+            )
+          )
+        )
+      )
+    ]);
+  }
+
+  void addTag(String tag, String type) {
+    List<String> changedList = getTagsList(type);
+    setState(() {
+      if(changedList.contains(tag)) {
+        ServiceHandler.displayToast('"$tag" is already in $type list');
+      } else {
+        changedList.add(tag);
+      }
+    });
+  }
+
+  void editTag(String newTag, int index, String type) {
+    List<String> changedList = getTagsList(type);
+    setState(() {
+      changedList[index] = newTag;
+    });
+  }
+
+  List<String> getTagsList(type) {
+    List<String> tagsList = [];
+    if(type == 'Hated') {
+      tagsList = hatedList;
+    } else if (type == 'Loved') {
+      tagsList = lovedList;
+    }
+    return tagsList;
+  }
+
+  void showFilterEntryActions(Widget row, String tag, int index, String type) {
+    showDialog(context: context, builder: (context) {
+      List<String> tagsList = getTagsList(type);
+      bool isAddButton = index == tagsList.length;
+      return StatefulBuilder(builder: (context, setDialogState) {
+        return InfoDialog(
+          null,
+          [
+            AbsorbPointer(absorbing: true, child: row),
+            const SizedBox(height: 20),
+            Container(
+              margin: EdgeInsets.fromLTRB(10,10,10,10),
+              width: double.infinity,
+              child: Row(
+                mainAxisSize: MainAxisSize.max,
+                children: <Widget>[
+                  Expanded(
+                    child: Container(
+                      margin: EdgeInsets.fromLTRB(10,0,0,0),
+                      child: TextField(
+                        autofocus: isAddButton ? true : false,
+                        controller: newTagController,
+                        onSubmitted: (String text) {
+                          if(text.trim() != '') {
+                            isAddButton
+                              ? addTag(text.trim().toLowerCase(), type)
+                              : editTag(text.trim().toLowerCase(), index, type);
+                            newTagController.text = '';
+                            Navigator.of(context).pop(true);
+                          } else {
+                            ServiceHandler.displayToast('Empty input!');
+                          }
+                        },
+                        decoration: InputDecoration(
+                          hintText: isAddButton ? "New $type Tag" : "Edit Tag",
+                          contentPadding: EdgeInsets.fromLTRB(15,0,15,0), // left,right,top,bottom
+                          border: OutlineInputBorder(
+                            borderRadius: BorderRadius.circular(50),
+                            gapPadding: 0,
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            TextButton.icon(
+              style: TextButton.styleFrom(
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(5),
+                  side: BorderSide(color: Get.context!.theme.accentColor),
+                ),
+              ),
+              onPressed: () async {
+                String text = newTagController.text;
+                if(text.trim() != '') {
+                  isAddButton
+                    ? addTag(text.trim().toLowerCase(), type)
+                    : editTag(text.trim().toLowerCase(), index, type);
+                  newTagController.text = '';
+                  Navigator.of(context).pop(true);
+                } else {
+                  ServiceHandler.displayToast('Empty input!');
+                }
+              },
+              icon: Icon(Icons.save),
+              label: Expanded(child: Text('Save', style: TextStyle(color: Colors.white))),
+            ),
+            if(!isAddButton)
+              TextButton.icon(
+                style: TextButton.styleFrom(
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(5),
+                    side: BorderSide(color: Get.context!.theme.accentColor),
+                  ),
+                ),
+                onPressed: () async {
+                  setState(() {
+                    if(type == 'Hated') {
+                      hatedList = tagsList.where((t) => t != tag).toList();
+                    } else if(type == 'Loved') {
+                      lovedList = tagsList.where((t) => t != tag).toList();
+                    }
+                  });
+                  Navigator.of(context).pop(true);
+                },
+                icon: Icon(Icons.delete_forever, color: Get.context!.theme.errorColor),
+                label: Expanded(child: Text('Delete', style: TextStyle(color: Get.context!.theme.errorColor))),
+              ),
+            const SizedBox(height: 5),
+          ],
+          CrossAxisAlignment.center
+        );
+      });
+    });
+  }
+}

--- a/lib/pages/settings/GalleryPage.dart
+++ b/lib/pages/settings/GalleryPage.dart
@@ -14,14 +14,16 @@ class GalleryPage extends StatefulWidget {
 }
 
 class _GalleryPageState extends State<GalleryPage> {
-  bool autoHideImageBar = false, autoPlay = true, loadingGif = false;
-  String? galleryMode;
+  bool autoHideImageBar = false, autoPlay = true, loadingGif = false, useVolumeButtonsForScroll = false;
+  String? galleryMode, galleryBarPosition;
   TextEditingController preloadController = new TextEditingController();
   @override
   void initState(){
     autoHideImageBar = widget.settingsHandler.autoHideImageBar;
     galleryMode = widget.settingsHandler.galleryMode;
+    galleryBarPosition = widget.settingsHandler.galleryBarPosition;
     autoPlay = widget.settingsHandler.autoPlayEnabled;
+    useVolumeButtonsForScroll = widget.settingsHandler.useVolumeButtonsForScroll;
     preloadController.text = widget.settingsHandler.preloadCount.toString();
     loadingGif = widget.settingsHandler.loadingGif;
     super.initState();
@@ -30,8 +32,10 @@ class _GalleryPageState extends State<GalleryPage> {
   Future<bool> _onWillPop() async {
     widget.settingsHandler.autoHideImageBar = autoHideImageBar;
     widget.settingsHandler.galleryMode = galleryMode!;
+    widget.settingsHandler.galleryBarPosition = galleryBarPosition!;
     widget.settingsHandler.autoPlayEnabled = autoPlay;
     widget.settingsHandler.loadingGif = loadingGif;
+    widget.settingsHandler.useVolumeButtonsForScroll = useVolumeButtonsForScroll;
     if (int.parse(preloadController.text) < 0){
       preloadController.text = 0.toString();
     }
@@ -126,6 +130,31 @@ class _GalleryPageState extends State<GalleryPage> {
                 ),
               ),
               Container(
+                margin: EdgeInsets.fromLTRB(10,10,10,10),
+                width: double.infinity,
+                child: Row(
+                  mainAxisSize: MainAxisSize.max,
+                  children: <Widget>[
+                    Text("Gallery Bar Position :     "),
+                    DropdownButton<String>(
+                      value: galleryBarPosition,
+                      icon: Icon(Icons.arrow_downward),
+                      onChanged: (String? newValue){
+                        setState((){
+                          galleryBarPosition = newValue;
+                        });
+                      },
+                      items: <String>["Top","Bottom"].map<DropdownMenuItem<String>>((String value){
+                        return DropdownMenuItem<String>(
+                          value: value,
+                          child: Text(value),
+                        );
+                      }).toList(),
+                    ),
+                  ],
+                ),
+              ),
+              Container(
                   margin: EdgeInsets.fromLTRB(10,10,10,10),
                   child: Row(children: [
                     Text("Auto Hide Gallery Bar: "),
@@ -169,6 +198,42 @@ class _GalleryPageState extends State<GalleryPage> {
                       activeColor: Get.context!.theme.primaryColor,
                     )
                   ],)
+              ),
+              Container(
+                  margin: EdgeInsets.fromLTRB(10,10,10,10),
+                  child: Row(
+                    mainAxisSize: MainAxisSize.max,
+                    children: [
+                      Text("Use Volume Buttons for Scrolling: "),
+                      Checkbox(
+                        value: useVolumeButtonsForScroll,
+                        onChanged: (newValue) {
+                          setState(() {
+                            useVolumeButtonsForScroll = newValue!;
+                          });
+                        },
+                        activeColor: Get.context!.theme.primaryColor,
+                      ),
+                      IconButton(
+                        icon: Icon(Icons.info, color: Get.context!.theme.accentColor),
+                        onPressed: () {
+                          Get.dialog(
+                              InfoDialog("Volume Buttons Scrolling",
+                                [
+                                  Text(" - Volume Down - next item"),
+                                  Text(" - Volume Up - previous item"),
+                                  const SizedBox(height: 10),
+                                  Text("On videos:"),
+                                  Text(" - App Bar visible - controls volume"),
+                                  Text(" - App Bar hidden - controls scrolling"),
+                                ],
+                                CrossAxisAlignment.start,
+                              )
+                          );
+                        },
+                      ),
+                    ],
+                  )
               ),
             ],
           ),

--- a/lib/widgets/BorderedText.dart
+++ b/lib/widgets/BorderedText.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/widgets.dart';
+
+// Taken from: https://github.com/tewshi/bordered-text
+
+/// Adds stroke to text widget
+/// We can apply a very thin and subtle stroke to a [Text]
+/// ```dart
+/// BorderedText(
+///   strokeWidth: 1.0,
+///   text: Text(
+///     'Bordered Text',
+///     style: TextStyle(
+///       decoration: TextDecoration.none,
+///       decorationStyle: TextDecorationStyle.wavy,
+///       decorationColor: Colors.red,
+///     ),
+///   ),
+/// )
+/// ```
+class BorderedText extends StatelessWidget {
+  BorderedText({
+    required this.child,
+    this.strokeCap = StrokeCap.round,
+    this.strokeJoin = StrokeJoin.round,
+    this.strokeWidth = 6.0,
+    this.strokeColor = const Color.fromRGBO(0, 0, 0, 1),
+  }) : assert(child is Text);
+
+  /// the stroke cap style
+  final StrokeCap strokeCap;
+
+  /// the stroke joint style
+  final StrokeJoin strokeJoin;
+
+  /// the stroke width
+  final double strokeWidth;
+
+  /// the stroke color
+  final Color strokeColor;
+
+  /// the [Text] widget to apply stroke on
+  final Text child;
+
+  @override
+  Widget build(BuildContext context) {
+    TextStyle style;
+    if (child.style != null) {
+      style = child.style!.copyWith(
+        foreground: Paint()
+          ..style = PaintingStyle.stroke
+          ..strokeCap = strokeCap
+          ..strokeJoin = strokeJoin
+          ..strokeWidth = strokeWidth
+          ..color = strokeColor,
+        color: null,
+      );
+    } else {
+      style = TextStyle(
+        foreground: Paint()
+          ..style = PaintingStyle.stroke
+          ..strokeCap = strokeCap
+          ..strokeJoin = strokeJoin
+          ..strokeWidth = strokeWidth
+          ..color = strokeColor,
+      );
+    }
+    return Stack(
+      alignment: Alignment.center,
+      textDirection: child.textDirection,
+      children: <Widget>[
+        Text(
+          child.data!,
+          style: style,
+          maxLines: child.maxLines,
+          overflow: child.overflow,
+          semanticsLabel: child.semanticsLabel,
+          softWrap: child.softWrap,
+          strutStyle: child.strutStyle,
+          textAlign: child.textAlign,
+          textDirection: child.textDirection,
+          textScaleFactor: child.textScaleFactor,
+        ),
+        child,
+      ],
+    );
+  }
+}

--- a/lib/widgets/CachedThumb.dart
+++ b/lib/widgets/CachedThumb.dart
@@ -2,21 +2,25 @@ import 'dart:io';
 import 'dart:ui';
 import 'dart:async';
 import 'dart:typed_data';
-import 'package:LoliSnatcher/ServiceHandler.dart';
+
 import 'package:flutter/widgets.dart';
 import 'package:get/get.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:dio/dio.dart';
+
 import 'package:LoliSnatcher/ImageWriter.dart';
+import 'package:LoliSnatcher/ServiceHandler.dart';
 import 'package:LoliSnatcher/SettingsHandler.dart';
+
 
 class CachedThumb extends StatefulWidget {
   final String thumbURL;
   final String thumbType;
   final int columnCount;
   final SettingsHandler settingsHandler;
-  CachedThumb(this.thumbURL,this.thumbType, this.settingsHandler, this.columnCount);
+  final bool isHated;
+  CachedThumb(this.thumbURL, this.thumbType, this.settingsHandler, this.columnCount, this.isHated);
   @override
   _CachedThumbState createState() => _CachedThumbState();
 }
@@ -25,31 +29,37 @@ class _CachedThumbState extends State<CachedThumb> {
   final ImageWriter imageWriter = ImageWriter();
   int _total = 0, _received = 0, _restartedCount = 0;
   bool? isFromCache;
-  bool isFailed = false;
+  // isFailed - loading error, isVisible - controls fade in
+  bool isFailed = false, isVisible = false, isForVideo = false;
   Timer? _debounceBytes, _restartDelay;
   Dio? _client;
   CancelToken? _dioCancelToken;
   ImageProvider? thumbProvider;
 
   /// Author: [Nani-Sore] ///
-  Future<void> _downloadImage() async {
-    final String? filePath = await imageWriter.getCachePath(widget.thumbURL, 'thumbnails');
+  Future<void> downloadThumb() async {
+    final String? filePath = await imageWriter.getCachePath(widget.thumbURL, widget.settingsHandler.previewMode == 'Sample' ? 'samples' : 'thumbnails');
+
+    int widthLimit = this.mounted ? ((MediaQuery.of(context).size.width / widget.columnCount) * MediaQuery.of(context).devicePixelRatio).round() : 200;
 
     // If file is in cache - load
     if (filePath != null) {
       final File file = File(filePath);
-      setState(() {
-        // multiple restates in the same function is usually bad practice, but we need this to notify user how the file is loaded while we await for bytes
-        isFromCache = true;
-      });
+
+      // multiple restates in the same function is usually bad practice, but we need this to notify user how the file is loaded while we await for bytes
+      isFromCache = true;
+      if(this.mounted) setState(() { });
       // load bytes first, then trigger an empty restate
-      thumbProvider = ResizeImage(MemoryImage(await file.readAsBytes()), width: 500); // allowUpscaling: true
-      setState(() {});
+      Uint8List bytes = await file.readAsBytes();
+      _total = bytes.lengthInBytes;
+      thumbProvider = ResizeImage(MemoryImage(bytes), width: widget.isHated ? 6 : widthLimit); // allowUpscaling: true
+
+      isVisible = true;
+      if(this.mounted) setState(() {});
       return;
     } else {
-      setState(() {
-        isFromCache = false;
-      });
+      isFromCache = false;
+      if(this.mounted) setState(() { });
     }
 
     //a few boorus doesn't work without a browser useragent
@@ -63,17 +73,19 @@ class _CachedThumbState extends State<CachedThumb> {
       options: Options(responseType: ResponseType.bytes, headers: headers),
       cancelToken: _dioCancelToken,
       onReceiveProgress: (received, total) {
-        _total = total;
+        if(total > 0) _total = total;
         _onBytesAdded(received);
       },
-    ).then((value) {
+    ).then((value) async {
       // Sometimes stream ends before fully loading, so we require at least 95% loaded to write to cache
       if (value.data != null && _received > (_total * 0.95)) {
-        // Sometimes stream ends before fully loading, so we require at least 95% loaded to write to cache
-        thumbProvider = ResizeImage(MemoryImage(Uint8List.fromList(value.data!)), width: 500); // allowUpscaling: true
-        setState((){ });
+        // resize thumbnail to 500px if wider OR 10px if contains hated tags
+        thumbProvider = ResizeImage(MemoryImage(Uint8List.fromList(value.data!)), width: widget.isHated ? 6 : widthLimit); // allowUpscaling: true
+
+        isVisible = true;
+        if(this.mounted) setState(() { });
         if (widget.settingsHandler.imageCache) {
-          imageWriter.writeCacheFromBytes(widget.thumbURL, value.data!, 'thumbnails');
+          imageWriter.writeCacheFromBytes(widget.thumbURL, value.data!, widget.settingsHandler.previewMode == 'Sample' ? 'samples' : 'thumbnails');
         }
       } else {
         print('Thumbnail load incomplete');
@@ -92,9 +104,9 @@ class _CachedThumbState extends State<CachedThumb> {
           _restartedCount++;
         } else {
           //show error
-          setState(() {
-            isFailed = true;
-          });
+          isFailed = true;
+          if(this.mounted) setState(() { });
+          // this.mounted prevents exceptions when using staggered view
         }
         print('Dio request cancelled: $e');
       }
@@ -104,14 +116,13 @@ class _CachedThumbState extends State<CachedThumb> {
   /// Author: [Nani-Sore] ///
   void _onBytesAdded(int addedBytes) {
     // always save incoming bytes, but restate only after [debounceDelay]MS
-    const int debounceDelay = 50;
+    const int debounceDelay = 250;
     bool isActive = _debounceBytes?.isActive ?? false;
+    _received = addedBytes;
     if (isActive) {
-      _received = addedBytes;
+      // 
     } else {
-      setState(() {
-        _received = addedBytes;
-      });
+      if(this.mounted) setState(() { });
       _debounceBytes = Timer(const Duration(milliseconds: debounceDelay), () {});
     }
   }
@@ -120,25 +131,41 @@ class _CachedThumbState extends State<CachedThumb> {
   void initState() {
     super.initState();
 
-    _downloadImage();
+    selectThumbProvider();
+  }
+
+  void selectThumbProvider() async {
+    // bool isVideo = widget.thumbType == "video" && (widget.thumbURL.endsWith(".webm") || widget.thumbURL.endsWith(".mp4"));
+    // if (isVideo) {
+    //   isForVideo = true; // disabled - hangs the app
+    // } else {
+    //   downloadThumb();
+    // }
+
+    downloadThumb();
+  }
+
+  Future<Uint8List?> getVideoThumb() async {
+    ServiceHandler serviceHandler = ServiceHandler();
+    Uint8List? bytes = await serviceHandler.makeVidThumb(widget.thumbURL);
+    return bytes;
   }
 
   void restartLoading() {
     disposables();
 
-    setState(() {
-      _total = 0;
-      _received = 0;
+    _total = 0;
+    _received = 0;
+    isFromCache = false;
+    if(this.mounted) setState(() { });
 
-      isFromCache = false;
-    });
-
-    _downloadImage();
+    selectThumbProvider();
   }
 
   @override
   void dispose() {
     disposables();
+    isVisible = false;
     super.dispose();
   }
 
@@ -152,14 +179,30 @@ class _CachedThumbState extends State<CachedThumb> {
     // _client?.close(force: true);
   }
 
-  Widget loadingElementBuilder(BuildContext ctx, Widget child, ImageChunkEvent? loadingProgress) {
+  Widget loadingElementBuilder(BuildContext ctx, Widget? child, ImageChunkEvent? loadingProgress) {
     // if (loadingProgress == null && !widget.settingsHandler.imageCache) {
     //   // Resulting image for network loaded thumbnail
     //   return child;
     // }
 
-    if(isFailed) {
-      return child;
+    if (isFailed) {
+      return Center(
+        child: InkWell(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Icon(Icons.broken_image),
+              Text("ERROR"),
+              Text("Tap to retry!"),
+            ]
+          ),
+          onTap: () => setState(() {
+            _restartedCount = 0;
+            isFailed = false;
+            restartLoading();
+          }),
+        )
+      );
     }
 
     bool hasProgressData = (loadingProgress != null && loadingProgress.expectedTotalBytes != null) || (_total > 0);
@@ -168,61 +211,93 @@ class _CachedThumbState extends State<CachedThumb> {
     int? totalBytes = (hasProgressData ? (isProgressFromCaching ? _total : loadingProgress!.expectedTotalBytes) : null);
 
     double? percentDone = (hasProgressData ? expectedBytes! / totalBytes! : null);
-    String percentDoneText = hasProgressData ? ((percentDone! * 100).toStringAsFixed(2) + '%') : 'Loading...';
+    String? percentDoneText = hasProgressData
+        ? ((percentDone ?? 0) == 1 ? null : '${(percentDone! * 100).toStringAsFixed(2)}%')
+        : (isFromCache == true ? '...' : null);
+
     return Column(
       mainAxisAlignment: MainAxisAlignment.center,
-      children: (isFromCache == null || isFromCache == true) ? [] : [
-        SizedBox(
-          height: 100 / widget.columnCount,
-          width: 100 / widget.columnCount,
-          child: CircularProgressIndicator(
-            strokeWidth: 16 / widget.columnCount,
-            valueColor: AlwaysStoppedAnimation<Color>(Colors.pink[300]!),
-            value: percentDone,
+      children: isFromCache == false
+        ? [
+          SizedBox(
+            height: 100 / widget.columnCount,
+            width: 100 / widget.columnCount,
+            child: CircularProgressIndicator(
+              strokeWidth: 14 / widget.columnCount,
+              valueColor: AlwaysStoppedAnimation<Color>(Colors.pink[300]!),
+              value: percentDone,
+            ),
           ),
-        ),
-        Padding(padding: EdgeInsets.only(bottom: 10)),
-        widget.columnCount < 4 // Text element overflows if too many thumbnails are shown
-            ? Text(
-          percentDoneText,
-          style: TextStyle(
-            fontSize: 12,
-          ),
-        )
-            : Container(),
-      ],
+          if(widget.columnCount < 4 && percentDoneText != null) // Text element overflows if too many thumbnails are shown
+            ...[
+              Padding(padding: EdgeInsets.only(bottom: 10)),
+              Text(
+                percentDoneText,
+                style: TextStyle(
+                  fontSize: 12,
+                ),
+              ),
+            ],
+        ]
+        : [],
     );
   }
 
   @override
   Widget build(BuildContext context) {
-    if (widget.thumbType == "video" &&
-        (widget.thumbURL.endsWith(".webm") || widget.thumbURL.endsWith(".mp4"))){
-      ServiceHandler serviceHandler = ServiceHandler();
-      return FutureBuilder(
-          future: serviceHandler.makeVidThumb(widget.thumbURL), // a previously-obtained Future<String> or null
-          builder: (BuildContext context, AsyncSnapshot<Uint8List?> snapshot) {
-            if (snapshot.connectionState == ConnectionState.done && snapshot.hasData){
-              return Image(
-                image: ResizeImage(MemoryImage(Uint8List.fromList(snapshot.data!)), width: 500), //ResizeImage(MemoryImage(_totalBytes), width: 500, allowUpscaling: true),
-                fit: widget.settingsHandler.previewDisplay == "Waterfall" ? BoxFit.cover : BoxFit.contain ,
-                width: widget.settingsHandler.previewDisplay == "Waterfall" ? double.infinity : Get.width,
-                height: widget.settingsHandler.previewDisplay == "Waterfall" ? double.infinity : null,
-              );
-            } else {
-              return CircularProgressIndicator();
-            }
-          }
-      );
-    } else if (thumbProvider == null) { // (_totalBytes.length == 0) {
-      return loadingElementBuilder(context, Center(child: Text("Error")), null);
-    } else {
-      return Image(
-        image: thumbProvider!, //ResizeImage(MemoryImage(_totalBytes), width: 500, allowUpscaling: true),
-        fit: widget.settingsHandler.previewDisplay == "Waterfall" ? BoxFit.cover : BoxFit.contain ,
-        width: widget.settingsHandler.previewDisplay == "Waterfall" ? double.infinity : Get.width,
-        height: widget.settingsHandler.previewDisplay == "Waterfall" ? double.infinity : null,
-      );
-    }
+    // set max width after which the image will be resized
+    // int widthLimit = this.mounted ? ((MediaQuery.of(context).size.width / widget.columnCount) * MediaQuery.of(context).devicePixelRatio).round() : 200;
+
+    // if(isForVideo) {
+    //   ServiceHandler serviceHandler = ServiceHandler();
+    //   return FutureBuilder(
+    //       future: serviceHandler.makeVidThumb(widget.thumbURL), // a previously-obtained Future<String> or null
+    //       builder: (BuildContext context, AsyncSnapshot<Uint8List?> snapshot) {
+    //         if (snapshot.connectionState == ConnectionState.done && snapshot.hasData){
+    //           return Image(
+    //             image: ResizeImage(MemoryImage(Uint8List.fromList(snapshot.data!)), width: 500), //ResizeImage(MemoryImage(_totalBytes), width: 500, allowUpscaling: true),
+    //             fit: widget.settingsHandler.previewDisplay == "Waterfall" ? BoxFit.cover : BoxFit.contain ,
+    //             width: widget.settingsHandler.previewDisplay == "Waterfall" ? double.infinity : Get.width,
+    //             height: widget.settingsHandler.previewDisplay == "Waterfall" ? double.infinity : null,
+    //           );
+    //         } else {
+    //           return CircularProgressIndicator();
+    //         }
+    //       }
+    //   );
+    // }
+
+    return Stack(
+      alignment: Alignment.center,
+      children: [
+        if(thumbProvider == null)
+          loadingElementBuilder(context, null, null),
+
+        AnimatedOpacity(
+          opacity: isVisible ? 1.0 : 0.0,
+          duration: Duration(milliseconds: 300),
+          child: thumbProvider != null
+            ? Image(
+              image: thumbProvider!, //ResizeImage(MemoryImage(_totalBytes), width: 500, allowUpscaling: true),
+              fit: BoxFit.contain, //widget.settingsHandler.previewDisplay == "Waterfall" ? BoxFit.cover : BoxFit.contain,
+              width: double.infinity, //widget.settingsHandler.previewDisplay == "Waterfall" ? double.infinity : null,
+              height: double.infinity, //widget.settingsHandler.previewDisplay == "Waterfall" ? double.infinity : null,
+            )
+            : null
+          ),
+
+        if(widget.isHated)
+          Container(
+            alignment: Alignment.center,
+            decoration: BoxDecoration(
+              color: Colors.black.withOpacity(0.66),
+              borderRadius: BorderRadius.circular(5),
+            ),
+            width: 50,
+            height: 50,
+            child: Icon(CupertinoIcons.eye_slash, color: Colors.white)
+          ),
+      ]
+    );
   }
 }

--- a/lib/widgets/DesktopImageListener.dart
+++ b/lib/widgets/DesktopImageListener.dart
@@ -23,7 +23,7 @@ class DesktopImageListener extends StatefulWidget {
   int globalsIndex;
   SettingsHandler settingsHandler;
   SnatchHandler snatchHandler;
-  DesktopImageListener(this.searchGlobals,this.globalsIndex, this.settingsHandler,this.snatchHandler);
+  DesktopImageListener(this.searchGlobals, this.globalsIndex, this.settingsHandler, this.snatchHandler);
   @override
   _DesktopImageListenerState createState() => _DesktopImageListenerState();
 }
@@ -34,7 +34,7 @@ class _DesktopImageListenerState extends State<DesktopImageListener> {
   }
   //This function decides what media widget to return
   Widget getImageWidget(BooruItem value){
-      if (!value.isVideo() ){
+      if (!value.isVideo()){
         return PhotoView(imageProvider: NetworkImage(value.fileURL));
       } else {
         if (Platform.isAndroid){
@@ -44,12 +44,13 @@ class _DesktopImageListenerState extends State<DesktopImageListener> {
               future: nothing(),
               builder: (BuildContext context, AsyncSnapshot snapshot) {
                 if (snapshot.connectionState == ConnectionState.done){
-                  return VideoApp(value, 1, 1, widget.settingsHandler,false);
+                  return VideoApp(value, 1, widget.searchGlobals[widget.globalsIndex], widget.settingsHandler, false);
                 } else {
                   return Center(child: CircularProgressIndicator());
                 }
               }
-          ),);
+            ),
+          );
         } else {
           return Center(
             child: Column(

--- a/lib/widgets/HideableAppbar.dart
+++ b/lib/widgets/HideableAppbar.dart
@@ -1,11 +1,8 @@
 import 'dart:ui';
 import 'package:flutter/material.dart';
 import 'package:flutter/cupertino.dart';
-import 'package:flutter/services.dart';
 
 import 'package:LoliSnatcher/SearchGlobals.dart';
-
-import '../ServiceHandler.dart';
 
 class HideableAppBar extends StatefulWidget implements PreferredSizeWidget {
   String title;
@@ -51,16 +48,23 @@ class _HideableAppBarState extends State<HideableAppBar> {
     return AnimatedContainer(
       duration: Duration(milliseconds: 200),
       curve: Curves.linear,
+      color: Colors.transparent,
       height:
           widget.searchGlobals.displayAppbar!.value ? widget.defaultHeight : 0.0,
       child: AppBar(
         // toolbarHeight: widget.defaultHeight,
+        // elevation: 0, // set to zero to disable a shadow behind
+        backgroundColor: Colors.transparent,
+        foregroundColor: Colors.white,
         leading: IconButton(
           // to ignore icon change
-          icon: Icon(Icons.arrow_back, color: Colors.black),
+          icon: Icon(Icons.arrow_back, color: Colors.white),
           onPressed: () => Navigator.of(context).pop(),
         ),
-        title: FittedBox(fit: BoxFit.fitWidth, child: Text(widget.title)),
+        title: FittedBox(
+          fit: BoxFit.fitWidth,
+          child: Text(widget.title, style: TextStyle(color: Colors.white)),
+        ),
         actions: widget.actions,
       ),
     );

--- a/lib/widgets/HideableControlsPadding.dart
+++ b/lib/widgets/HideableControlsPadding.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/cupertino.dart';
+
+import 'package:LoliSnatcher/SearchGlobals.dart';
+
+// used to move up the video controls when using the bottom app bar
+
+class HideableControlsPadding extends StatefulWidget {
+  SearchGlobals searchGlobals;
+  ValueNotifier<bool> isFullscreen;
+  Widget controls;
+  HideableControlsPadding(this.searchGlobals, this.isFullscreen, this.controls);
+
+  final double defaultHeight = kToolbarHeight; //56.0
+
+  @override
+  _HideableControlsPaddingState createState() => _HideableControlsPaddingState();
+}
+
+class _HideableControlsPaddingState extends State<HideableControlsPadding> {
+  bool isVisible = false;
+
+  @override
+  void initState() {
+    super.initState();
+    isVisible = widget.searchGlobals.displayAppbar!.value;
+    widget.searchGlobals.displayAppbar?.addListener(setSt);
+    widget.isFullscreen.addListener(setStOnFullScreen);
+  }
+
+  void setSt() {
+    isVisible = widget.searchGlobals.displayAppbar!.value;
+    setState(() {});
+  }
+
+  void setStOnFullScreen() {
+    if(widget.isFullscreen.value) {
+      isVisible = false;
+    } else {
+      isVisible = widget.searchGlobals.displayAppbar!.value;
+    }
+    setState(() {});
+  }
+
+  @override
+  void dispose() {
+    widget.searchGlobals.displayAppbar?.removeListener(setSt);
+    widget.isFullscreen.removeListener(setStOnFullScreen);
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedPadding(
+      duration: Duration(milliseconds: 200),
+      curve: Curves.linear,
+      padding: EdgeInsets.only(bottom: isVisible ? widget.defaultHeight : 0.0),
+      child: widget.controls,
+    );
+  }
+}

--- a/lib/widgets/ImagePreviews.dart
+++ b/lib/widgets/ImagePreviews.dart
@@ -1,20 +1,20 @@
-import 'package:LoliSnatcher/SettingsHandler.dart';
-import 'package:LoliSnatcher/SnatchHandler.dart';
-import 'package:LoliSnatcher/libBooru/Booru.dart';
-import 'package:LoliSnatcher/pages/settings/BooruEditPage.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 
-import '../SearchGlobals.dart';
-import 'StaggeredView.dart';
-import 'WaterfallView.dart';
+import 'package:LoliSnatcher/SearchGlobals.dart';
+import 'package:LoliSnatcher/SettingsHandler.dart';
+import 'package:LoliSnatcher/SnatchHandler.dart';
+import 'package:LoliSnatcher/libBooru/Booru.dart';
+import 'package:LoliSnatcher/pages/settings/BooruEditPage.dart';
+import 'package:LoliSnatcher/widgets/WaterfallView.dart';
 
 class ImagePreviews extends StatefulWidget {
   SettingsHandler settingsHandler;
   SearchGlobals searchGlobals;
   SnatchHandler snatchHandler;
-  ImagePreviews(this.settingsHandler,this.searchGlobals,this.snatchHandler);
+  Function searchAction;
+  ImagePreviews(this.settingsHandler, this.searchGlobals, this.snatchHandler, this.searchAction);
   @override
   _ImagePreviewsState createState() => _ImagePreviewsState();
 }
@@ -58,11 +58,7 @@ class _ImagePreviewsState extends State<ImagePreviews> {
             builder: (BuildContext context, AsyncSnapshot snapshot) {
               if (snapshot.connectionState == ConnectionState.done){
                 if (widget.searchGlobals.selectedBooru != null){
-                  if (widget.settingsHandler.previewDisplay == "Waterfall"){
-                    return WaterfallView(widget.settingsHandler,widget.searchGlobals,widget.snatchHandler);
-                  } else {
-                    return StaggeredView(widget.settingsHandler,widget.searchGlobals,widget.snatchHandler);
-                  }
+                  return WaterfallView(widget.settingsHandler, widget.searchGlobals, widget.snatchHandler, widget.searchAction);
                 } else {
                   return Center(child: CircularProgressIndicator());
                 }

--- a/lib/widgets/TabBox.dart
+++ b/lib/widgets/TabBox.dart
@@ -46,7 +46,7 @@ class _TabBoxState extends State<TabBox> {
                   setState(() {
                     //widget.globalsIndex = widget.searchGlobals.indexOf(newValue!);
                     if (newValue != null){
-                      widget.searchTagsController.text = newValue.tags!;
+                      widget.searchTagsController.text = newValue.tags;
                       widget.setParentGlobalsIndex(widget.searchGlobals.indexOf(newValue), null);
                     }
                   });
@@ -63,17 +63,17 @@ class _TabBoxState extends State<TabBox> {
                     child: Row(
                         children: [
                           isNotEmptyBooru
-                              ? (value.selectedBooru!.type == "Favourites"
+                            ? (value.selectedBooru!.type == "Favourites"
                               ? Icon(Icons.favorite, color: Colors.red, size: 18)
                               : Image.network(
-                              value.selectedBooru!.faviconURL!,
-                              width: 16,
-                              errorBuilder: (_, __, ___) {
-                                return Icon(Icons.broken_image, size: 18);
-                              }
-                          )
-                          )
-                              : Icon(CupertinoIcons.question, size: 18),
+                                value.selectedBooru!.faviconURL!,
+                                width: 16,
+                                errorBuilder: (_, __, ___) {
+                                  return Icon(Icons.broken_image, size: 18);
+                                }
+                              )
+                            )
+                            : Icon(CupertinoIcons.question, size: 18),
                           const SizedBox(width: 3),
                           Expanded(child: ScrollingText(tagText, 22, "infiniteWithPause", value.tags == "" ? Colors.grey : Colors.white)),
                         ]

--- a/lib/widgets/TagSearchBox.dart
+++ b/lib/widgets/TagSearchBox.dart
@@ -33,10 +33,6 @@ class _TagSearchBoxState extends State<TagSearchBox> {
         widget.searchGlobals.booruHandler!.booru.apiKey != "" &&
         widget.searchGlobals.booruHandler!.booru.userID != "") {
       widget.searchGlobals.booruHandler!.tagSearchEnabled = false;
-    } else if (widget.searchGlobals.booruHandler!.booru.type == "Shimmie" &&
-        widget.searchGlobals.booruHandler!.booru.baseURL!
-            .contains("rule34.paheal.net")) {
-      widget.searchGlobals.booruHandler!.tagSearchEnabled = false;
     }
   }
   @override
@@ -101,8 +97,7 @@ class _TagSearchBoxState extends State<TagSearchBox> {
         // Get last tag in the input and remove minus (exclude symbol)
         // TODO /bug?: use the tag behind the current cursor position, not the last tag
         setState(() {
-          lastTag = splitInput[splitInput.length - 1].replaceAll(
-              new RegExp(r'^-'), '');
+          lastTag = splitInput[splitInput.length - 1].replaceAll(new RegExp(r'^-'), '');
         });
       }
     }
@@ -195,14 +190,14 @@ class _TagSearchBoxState extends State<TagSearchBox> {
             fillColor: Get.context!.theme.canvasColor,
             filled: true,
             hintText: "Enter Tags",
-            suffixIcon: widget.searchTagsController.text.length > 0
-                ? IconButton(
-              padding: const EdgeInsets.all(5),
-              onPressed: () => widget.searchTagsController.clear(),
-              icon: Icon(Icons.clear),
-            )
-                : Container(width: 0.0),
-            contentPadding: EdgeInsets.fromLTRB(15, 0, 0, 0), // left,top,right,bottom
+            prefixIcon: widget.searchTagsController.text.length > 0
+              ? IconButton(
+                  padding: const EdgeInsets.all(5),
+                  onPressed: () => setState(() {widget.searchTagsController.clear();}),
+                  icon: Icon(Icons.clear),
+                )
+              : null,
+            contentPadding: EdgeInsets.fromLTRB(15, 0, 10, 0), // left,top,right,bottom
             border: new OutlineInputBorder(
               borderRadius: new BorderRadius.circular(30),
               gapPadding: 0,

--- a/lib/widgets/TagView.dart
+++ b/lib/widgets/TagView.dart
@@ -1,34 +1,69 @@
-import 'package:LoliSnatcher/libBooru/BooruItem.dart';
+import 'package:LoliSnatcher/SettingsHandler.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:get/get.dart';
 
-import '../SearchGlobals.dart';
-import '../ServiceHandler.dart';
+import 'package:LoliSnatcher/SearchGlobals.dart';
+import 'package:LoliSnatcher/ServiceHandler.dart';
+import 'package:LoliSnatcher/libBooru/BooruItem.dart';
 
 class TagView extends StatefulWidget {
   BooruItem booruItem;
   SearchGlobals searchGlobals;
-  TagView(this.booruItem,this.searchGlobals);
+  SettingsHandler settingsHandler;
+  TagView(this.booruItem, this.searchGlobals, this.settingsHandler);
   @override
   _TagViewState createState() => _TagViewState();
 }
 
 class _TagViewState extends State<TagView> {
+  List<List<String>> hatedAndLovedTags = [];
+
+  @override
+  void initState() {
+    super.initState();
+    hatedAndLovedTags = widget.settingsHandler.parseTagsList(widget.booruItem.tagsList, isCapped: false);
+  }
+
   @override
   Widget build(BuildContext context) {
    return Container(
       margin: EdgeInsets.all(5),
       child: ListView.builder(
-          itemCount: widget.booruItem.tagsList!.length,
+          itemCount: widget.booruItem.tagsList.length,
           itemBuilder: (BuildContext context, int index) {
-            String currentTag = widget.booruItem.tagsList![index];
+            String currentTag = widget.booruItem.tagsList[index];
+            bool isHated = hatedAndLovedTags[0].contains(currentTag);
+            bool isLoved = hatedAndLovedTags[1].contains(currentTag);
+            Color tagColor = Colors.white;
+            IconData? tagIcon;
+            if(isHated) {
+              tagColor = Colors.red;
+              tagIcon = CupertinoIcons.eye_slash;
+            } else if (isLoved) {
+              tagColor = Colors.yellow;
+              tagIcon = Icons.star;
+            }
+
             if (currentTag != '') {
               return Column(children: <Widget>[
                 Row(
                   children: [
+                    const SizedBox(width: 5),
+                    if(tagIcon != null)
+                      ...[
+                        Icon(tagIcon, color: tagColor),
+                        const SizedBox(width: 5),
+                      ],
                     Expanded(
-                      child: Text(currentTag),
+                      child: GestureDetector(
+                        onLongPress: () {
+                          Clipboard.setData(new ClipboardData(text: currentTag));
+                          ServiceHandler.displayToast('Text copied to clipboard!');
+                        },
+                        child: Text(currentTag, style: TextStyle(fontSize: 16)),
+                      )
                     ),
                     IconButton(
                       icon: Icon(
@@ -39,7 +74,7 @@ class _TagViewState extends State<TagView> {
                         setState(() {
                           widget.searchGlobals.addTag!.value = " " + currentTag;
                         });
-                        ServiceHandler.displayToast("Added to search \n Tag: "+ currentTag);
+                        ServiceHandler.displayToast("Added to search\nTag: "+ currentTag);
                         //Get.snackbar("Added to search", "Tag: " + currentTag, snackPosition: SnackPosition.BOTTOM, duration: Duration(seconds: 2), colorText: Colors.black, backgroundColor: Get.context!.theme.primaryColor);
                       },
                     ),
@@ -50,7 +85,7 @@ class _TagViewState extends State<TagView> {
                         setState(() {
                           widget.searchGlobals.newTab!.value = currentTag;
                         });
-                        ServiceHandler.displayToast("Added new tab \n Tag: " + currentTag);
+                        ServiceHandler.displayToast("Added new tab\nTag: " + currentTag);
                         //Get.snackbar("Added new tab", "Tag: " + currentTag, snackPosition: SnackPosition.BOTTOM, duration: Duration(seconds: 2), colorText: Colors.black, backgroundColor: Get.context!.theme.primaryColor);
                       },
                     ),

--- a/lib/widgets/WaterfallView.dart
+++ b/lib/widgets/WaterfallView.dart
@@ -1,15 +1,19 @@
+import 'dart:async';
+import 'dart:math';
+
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:get/get.dart';
+import 'package:flutter_staggered_grid_view/flutter_staggered_grid_view.dart';
 
 import 'package:LoliSnatcher/SearchGlobals.dart';
 import 'package:LoliSnatcher/SnatchHandler.dart';
 import 'package:LoliSnatcher/SettingsHandler.dart';
 
 import 'package:LoliSnatcher/ViewUtils.dart';
-import 'package:LoliSnatcher/ServiceHandler.dart';
 import 'package:LoliSnatcher/libBooru/BooruHandlerFactory.dart';
+import 'package:LoliSnatcher/libBooru/BooruItem.dart';
 import 'package:LoliSnatcher/widgets/ViewerPage.dart';
 
 
@@ -17,35 +21,282 @@ class WaterfallView extends StatefulWidget {
   final SearchGlobals searchGlobals;
   final SettingsHandler settingsHandler;
   final SnatchHandler snatchHandler;
-  WaterfallView(this.settingsHandler, this.searchGlobals, this.snatchHandler);
+  final Function searchAction;
+  WaterfallView(this.settingsHandler, this.searchGlobals, this.snatchHandler, this.searchAction);
   @override
   _WaterfallState createState() => _WaterfallState();
 }
 
 class _WaterfallState extends State<WaterfallView> {
   ScrollController gridController = ScrollController();
-  bool isLastPage = false;
+  bool isLastPage = false, isLoading = true;
+  Timer? loadingDelay;
+  List<BooruItem> fetched = [];
   FocusNode kbFocusNode = FocusNode();
+
   void setBooruHandler() {
-    List temp = new BooruHandlerFactory()
-        .getBooruHandler(widget.searchGlobals.selectedBooru!, widget.settingsHandler.limit, widget.settingsHandler.dbHandler);
+    List temp = BooruHandlerFactory().getBooruHandler(widget.searchGlobals.selectedBooru!, widget.settingsHandler.limit, widget.settingsHandler.dbHandler);
     widget.searchGlobals.booruHandler = temp[0];
     widget.searchGlobals.pageNum = temp[1];
   }
+
   @override
   void initState() {
     super.initState();
+    // get booru handler
+    if (widget.searchGlobals.booruHandler == null) {
+      setBooruHandler();
+    }
+
+    // restore scroll position on tab change
+    if (gridController.hasClients) {
+      gridController.jumpTo(widget.searchGlobals.scrollPosition);
+    } else if (widget.searchGlobals.scrollPosition != 0) {
+      setState(() {
+        gridController = ScrollController(initialScrollOffset: widget.searchGlobals.scrollPosition);
+      });
+    }
+
+    // trigger first load OR get old fetched list
+    bool isNewSearch = widget.searchGlobals.booruHandler!.fetched.length == 0;
+    if(isNewSearch) { // don't trigger search if there are items inside booruhandler
+      filteredSearch();
+    } else {
+      isLoading = false;
+      fetched = widget.searchGlobals.booruHandler!.fetched;
+      filterFetched();
+    }
+
+    // restore isLastPage state
+    if(widget.searchGlobals.booruHandler!.locked) {
+      isLastPage = true;
+    }
+
     // Stops previous pages being forgotten when switching tabs
     widget.searchGlobals.viewedIndex!.addListener(jumpTo);
   }
-  void jumpTo(){
-    ViewUtils.jumpToItem(widget.searchGlobals.viewedIndex!.value,widget.searchGlobals,gridController,widget.settingsHandler,context);
-  }
+
   @override
   void dispose() {
     widget.searchGlobals.viewedIndex!.removeListener(jumpTo);
     kbFocusNode.dispose();
+    loadingDelay?.cancel();
     super.dispose();
+  }
+
+  void jumpTo(){
+    ViewUtils.jumpToItem(widget.searchGlobals.viewedIndex!.value, widget.searchGlobals, gridController, widget.settingsHandler, context);
+  }
+
+  void filteredSearch() async {
+    if(isLastPage) return;
+
+    if (!widget.searchGlobals.booruHandler!.locked) {
+      isLoading = true;
+      widget.searchGlobals.pageNum++;
+    }
+    if(this.mounted) setState(() { });
+
+    // fetch new items, but get results from booruhandler and not search itself
+    // TODO is having a second copy of the list okay?
+    await widget.searchGlobals.booruHandler!.Search(widget.searchGlobals.tags, widget.searchGlobals.pageNum);
+    fetched = widget.searchGlobals.booruHandler!.fetched;
+
+    // filter out items with hated images
+    filterFetched();
+
+    // lock new loads if handler detected last page (previous fetched length == current length)
+    if (widget.searchGlobals.booruHandler!.locked && !isLastPage) {
+      isLastPage = true;
+    }
+    
+    // delay every new page load after fetching 100+ images
+    if(fetched.length > 100) {
+      loadingDelay = Timer(Duration(milliseconds: 200), () {
+        isLoading = false;
+        if(this.mounted) setState(() { });
+      });
+    } else {
+      isLoading = false;
+    }
+
+    // desktop view first load setter?
+    if (fetched.length > 0){
+      if(widget.searchGlobals.currentItem.value.fileURL.isEmpty){
+        print("setting booruItem value");
+        widget.searchGlobals.currentItem.value = fetched[0];
+      }
+    }
+
+    if(this.mounted) setState(() { });
+    // this.mounted prevents an exception on first load
+  }
+
+  void filterFetched() {
+    if(widget.settingsHandler.filterHated) {
+      fetched = fetched.where((item) => widget.settingsHandler.parseTagsList(item.tagsList)[0].length == 0).toList();
+    }
+  }
+
+  Widget gridBuilder() {
+    int columnsCount =
+        (MediaQuery.of(context).orientation == Orientation.portrait)
+            ? widget.settingsHandler.portraitColumns
+            : widget.settingsHandler.landscapeColumns;
+
+    return GridView.builder(
+      controller: gridController,
+      physics: BouncingScrollPhysics(),
+      addAutomaticKeepAlives: true,
+      cacheExtent: 100,
+      itemCount: fetched.length,
+      gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(crossAxisCount: columnsCount),
+      itemBuilder: (BuildContext context, int index) {
+        bool isSelected = widget.searchGlobals.selected.contains(index);
+        return Card(
+          margin: EdgeInsets.all(2),
+          child: GridTile(
+            // Inkresponse is used so the tile can have an onclick function
+            child: Material(
+              borderOnForeground: true,
+              child: Ink(
+                decoration: isSelected
+                    ? BoxDecoration(
+                  border: Border.all(
+                      color: Get.context!.theme.accentColor,
+                      width: 4.0),
+                )
+                    : null,
+                child: InkResponse(
+                  enableFeedback: true,
+                  highlightShape: BoxShape.rectangle,
+                  containedInkWell: true,
+                  highlightColor: Get.context!.theme.accentColor,
+                  child: ViewUtils.sampleorThumb(fetched[index], columnsCount,widget.settingsHandler),
+                  onTap: () {
+                    // Load the image viewer
+                    kbFocusNode.unfocus();
+                    if (widget.settingsHandler.appMode == "Mobile"){
+                      Get.dialog(
+                        ViewerPage(fetched, index, widget.searchGlobals, widget.settingsHandler, widget.snatchHandler),
+                        transitionDuration: Duration(milliseconds: 200),
+                        // barrierColor: Colors.transparent
+                      ).whenComplete(() {
+                        //SystemChrome.setEnabledSystemUIOverlays(SystemUiOverlay.values);
+                        kbFocusNode.requestFocus();
+                      });
+                    } else {
+                      widget.searchGlobals.currentItem.value = fetched[index];
+                    }
+
+
+                    // Get.to(ImagePage(fetched, index, widget.searchGlobals, widget.settingsHandler, widget.snatchHandler));
+                  },
+                  onLongPress: () {
+                    if (widget.searchGlobals.selected.contains(index)) {
+                      setState(() {
+                        widget.searchGlobals.selected.remove(index);
+                      });
+                    } else {
+                      setState(() {
+                        widget.searchGlobals.selected.add(index);
+                      });
+                    }
+                  },
+                ),
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  Widget staggeredBuilder() {
+    int columnsCount =
+        (MediaQuery.of(context).orientation == Orientation.portrait)
+            ? widget.settingsHandler.portraitColumns
+            : widget.settingsHandler.landscapeColumns;
+    double itemMaxWidth = MediaQuery.of(context).size.width / columnsCount;
+    double itemMaxHeight = MediaQuery.of(context).size.height * 0.75;
+
+    return StaggeredGridView.countBuilder(
+      controller: gridController,
+      physics: BouncingScrollPhysics(),
+      addAutomaticKeepAlives: true,
+      itemCount: fetched.length,
+      crossAxisCount: columnsCount,
+      itemBuilder: (BuildContext context, int index) {
+        bool isSelected = widget.searchGlobals.selected.contains(index);
+
+        double? widthData = fetched[index].fileWidth ?? null;
+        double? heightData = fetched[index].fileHeight ?? null;
+        
+        double possibleWidth = itemMaxWidth;
+        double possibleHeight = itemMaxWidth;
+        bool hasSizeData = heightData != null && widthData != null;
+        if(hasSizeData) {
+          double aspectRatio = widthData / heightData;
+          possibleHeight = possibleWidth / aspectRatio;
+        }
+        // force to use minimum 100 px and max 75% of screen height
+        possibleHeight = max(min(itemMaxHeight, possibleHeight), 100);
+        
+        return Container(
+          height: possibleHeight,
+          width: possibleWidth,
+          // constraints: hasSizeData
+          //     ? BoxConstraints(minHeight: possibleHeight, maxHeight: possibleHeight, minWidth: possibleWidth, maxWidth: possibleWidth)
+          //     : BoxConstraints(minHeight: possibleWidth, maxHeight: double.infinity, minWidth: possibleWidth, maxWidth: possibleWidth),
+          // Inkresponse is used so the tile can have an onclick function
+          child: Material(
+            borderOnForeground: true,
+            child: Ink(
+              decoration: isSelected ? BoxDecoration(border: Border.all(color: Get.context!.theme.accentColor, width: 4.0),) : null,
+              child: InkResponse(
+                enableFeedback: true,
+                highlightShape: BoxShape.rectangle,
+                containedInkWell: true,
+                highlightColor: Get.context!.theme.accentColor,
+                child: ViewUtils.sampleorThumb(fetched[index], columnsCount,widget.settingsHandler),
+                onTap: () {
+                  // Load the image viewer
+                  kbFocusNode.unfocus();
+                  if (widget.settingsHandler.appMode == "Mobile"){
+                    Get.dialog(
+                      ViewerPage(fetched, index, widget.searchGlobals, widget.settingsHandler, widget.snatchHandler),
+                      transitionDuration: Duration(milliseconds: 200),
+                      // barrierColor: Colors.transparent
+                    ).whenComplete(() {
+                      //SystemChrome.setEnabledSystemUIOverlays(SystemUiOverlay.values);
+                      kbFocusNode.requestFocus();
+                    });
+                  } else {
+                    widget.searchGlobals.currentItem.value = fetched[index];
+                  }
+
+                  // Get.to(ImagePage(fetched, index, widget.searchGlobals, widget.settingsHandler, widget.snatchHandler));
+                },
+                onLongPress: () {
+                  if (widget.searchGlobals.selected.contains(index)) {
+                    setState(() {
+                      widget.searchGlobals.selected.remove(index);
+                    });
+                  } else {
+                    setState(() {
+                      widget.searchGlobals.selected.add(index);
+                    });
+                  }
+                },
+              ),
+            ),
+          ),
+        );
+      },
+      staggeredTileBuilder: (int index) => StaggeredTile.fit(1),
+      mainAxisSpacing: 4.0,
+      crossAxisSpacing: 4.0,
+    );
   }
 
   @override
@@ -56,150 +307,80 @@ class _WaterfallState extends State<WaterfallView> {
       print("kb focus node requesting focus");
       //kbFocusNode.requestFocus();
     }
-    if (widget.searchGlobals.booruHandler == null) {
-      setBooruHandler();
-    }
-    if (gridController.hasClients) {
-      gridController.jumpTo(widget.searchGlobals.scrollPosition);
-    } else if (widget.searchGlobals.scrollPosition != 0) {
-      setState(() {
-        gridController = new ScrollController(
-            initialScrollOffset: widget.searchGlobals.scrollPosition);
-      });
-    }
 
     int columnsCount =
         (MediaQuery.of(context).orientation == Orientation.portrait)
             ? widget.settingsHandler.portraitColumns
             : widget.settingsHandler.landscapeColumns;
-    return FutureBuilder(
-        future: widget.searchGlobals.booruHandler!
-            .Search(widget.searchGlobals.tags!, widget.searchGlobals.pageNum),
-        builder: (context, AsyncSnapshot snapshot) {
-          if (!snapshot.hasData) {
-            return Center(child: CircularProgressIndicator());
-          } else {
-            /*if(widget.settingsHandler.appMode == "Desktop"){
-              if (snapshot.data.length > 0){
-                if(widget.searchGlobals.currentItem.value.fileURL!.isEmpty){
-                  print("setting booruItem value");
-                  widget.searchGlobals.currentItem.value = snapshot.data[0];
-                }
-              }
-            }*/
-            // A notification listener is used to get the scroll position
-            return RawKeyboardListener(
-              autofocus: false,
-              focusNode: kbFocusNode,
-              onKey: (RawKeyEvent event){
-                if (event.runtimeType == RawKeyDownEvent){
-                  if(event.isKeyPressed(LogicalKeyboardKey.arrowDown) || event.isKeyPressed(LogicalKeyboardKey.keyJ)){
-                    gridController.animateTo(gridController.offset + 50, duration: Duration(milliseconds: 50), curve: Curves.linear);
-                  } else if(event.isKeyPressed(LogicalKeyboardKey.arrowUp) || event.isKeyPressed(LogicalKeyboardKey.keyK)){
-                    gridController.animateTo(gridController.offset - 50, duration: Duration(milliseconds: 50), curve: Curves.linear);
-                  }
-                }
-              },
-              child: NotificationListener<ScrollUpdateNotification>(
-                child: Scrollbar(
-                  controller: gridController,
-                  isAlwaysShown: true,
-                  child: GridView.builder(
-                    controller: gridController,
-                    itemCount: snapshot.data.length,
-                    gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-                        crossAxisCount: columnsCount),
-                    itemBuilder: (BuildContext context, int index) {
-                      bool isSelected = widget.searchGlobals.selected!.contains(index);
-                      return new Card(
-                        child: new GridTile(
-                          // Inkresponse is used so the tile can have an onclick function
-                          child: Material(
-                            borderOnForeground: true,
-                            child: Ink(
-                              decoration: isSelected
-                                  ? BoxDecoration(
-                                border: Border.all(
-                                    color: Get.context!.theme.accentColor,
-                                    width: 4.0),
-                              )
-                                  : null,
-                              child: new InkResponse(
-                                enableFeedback: true,
-                                highlightShape: BoxShape.rectangle,
-                                containedInkWell: true,
-                                highlightColor: Get.context!.theme.accentColor,
-                                child: ViewUtils.sampleorThumb(snapshot.data[index], columnsCount,widget.settingsHandler),
-                                onTap: () {
-                                  // Load the image viewer
-                                  kbFocusNode.unfocus();
-                                  if (widget.settingsHandler.appMode == "Mobile"){
-                                    Get.dialog(
-                                      ViewerPage(snapshot.data, index, widget.searchGlobals, widget.settingsHandler, widget.snatchHandler),
-                                      transitionDuration: Duration(milliseconds: 200),
-                                      // barrierColor: Colors.transparent
-                                    ).whenComplete(() {
-                                      //SystemChrome.setEnabledSystemUIOverlays(SystemUiOverlay.values);
-                                      kbFocusNode.requestFocus();
-                                    });
-                                  } else {
-                                    widget.searchGlobals.currentItem.value = snapshot.data[index];
-                                  }
-
-
-                                  // Get.to(ImagePage(snapshot.data, index, widget.searchGlobals, widget.settingsHandler, widget.snatchHandler));
-                                },
-                                onLongPress: () {
-                                  if (widget.searchGlobals.selected!.contains(index)) {
-                                    setState(() {
-                                      widget.searchGlobals.selected!.remove(index);
-                                    });
-                                  } else {
-                                    setState(() {
-                                      widget.searchGlobals.selected!.add(index);
-                                    });
-                                  }
-                                },
-                              ),
-                            ),
-                          ),
-                        ),
-                      );
-                    },
-                  ),
-                ),
-                onNotification: (notif) {
-                  widget.searchGlobals.scrollPosition = gridController.offset;
-                  //print('SCROLL NOTIFICATION');
-                  //print(gridController.position.maxScrollExtent);
-                  //print(notif.metrics); // pixels before viewport, in viewport, after viewport
-
-                  // If at bottom edge update state with incremented pageNum
-                  bool isNotAtStart = notif.metrics.pixels > 0;
-                  //bool isNearEdge = notif.metrics.pixels > notif.metrics.maxScrollExtent - 25;
-                  bool isAtEdge = notif.metrics.atEdge;
-                  bool isScreenFilled = notif.metrics.extentBefore > 0 || notif.metrics.extentAfter > 0; // for cases when first page doesn't fill the screen (example: too many thumbnails per row)
-                  if ((isNotAtStart || !isScreenFilled) && isAtEdge) {
-                    if (!widget.searchGlobals.booruHandler!.locked) {
-                      setState(() {
-                        widget.searchGlobals.pageNum++;
-                      });
-                      ServiceHandler.displayToast("Loading next page...\n Page #" + widget.searchGlobals.pageNum.toString());
-                      //Get.snackbar("Loading next page...", 'Page #' + widget.searchGlobals.pageNum.toString(), snackPosition: SnackPosition.TOP, duration: Duration(seconds: 2), colorText: Colors.black, backgroundColor: Get.context!.theme.primaryColor);
-                    } else if (!isLastPage) {
-                      setState(() {
-                        isLastPage = true;
-                      });
-                      ServiceHandler.displayToast("No More Files \n (T⌓T)");
-                      //Get.snackbar("No More Files", '(T⌓T)', snackPosition: SnackPosition.TOP, duration: Duration(seconds: 2), colorText: Colors.black, backgroundColor: Get.context!.theme.primaryColor);
-                    }
-                  }
-                  return true;
-                },
-              ),
-            );
-
+    return RawKeyboardListener(
+      autofocus: false,
+      focusNode: kbFocusNode,
+      onKey: (RawKeyEvent event){
+        if (event.runtimeType == RawKeyDownEvent){
+          if(event.isKeyPressed(LogicalKeyboardKey.arrowDown) || event.isKeyPressed(LogicalKeyboardKey.keyJ)){
+            gridController.animateTo(gridController.offset + 50, duration: Duration(milliseconds: 50), curve: Curves.linear);
+          } else if(event.isKeyPressed(LogicalKeyboardKey.arrowUp) || event.isKeyPressed(LogicalKeyboardKey.keyK)){
+            gridController.animateTo(gridController.offset - 50, duration: Duration(milliseconds: 50), curve: Curves.linear);
           }
-        });
+        }
+      },
+      child: Column(
+        children: [
+          if(fetched.length == 0 && !isLastPage)
+            Expanded(child: Center(child: CircularProgressIndicator())),
+          Expanded(
+            child: NotificationListener<ScrollUpdateNotification>(
+              child: Scrollbar(
+                controller: gridController,
+                isAlwaysShown: true,
+                child: RefreshIndicator(
+                  displacement: 80,
+                  strokeWidth: 4,
+                  onRefresh: () async {
+                    widget.searchAction(widget.searchGlobals.tags);
+                    return;
+                  },
+                  // TODO: temporary fallback to waterfall if booru doesn't give image sizes in api, until staggered view is fixed
+                  child: (widget.settingsHandler.previewDisplay == 'Waterfall' || !widget.searchGlobals.booruHandler!.hasSizeData) ? gridBuilder() : staggeredBuilder(),
+                ),
+              ),
+              onNotification: (notif) {
+                widget.searchGlobals.scrollPosition = gridController.offset;
+
+                //print('SCROLL NOTIFICATION');
+                //print(gridController.position.maxScrollExtent);
+                //print(notif.metrics); // pixels before viewport, in viewport, after viewport
+
+                bool isNotAtStart = notif.metrics.pixels > 0;
+                bool isAtOrNearEdge = notif.metrics.atEdge || notif.metrics.pixels > (notif.metrics.maxScrollExtent - (notif.metrics.extentInside * 2)); // trigger new page when at edge or scroll position is less than 2 viewports
+                bool isScreenFilled = notif.metrics.extentBefore != 0 || notif.metrics.extentAfter != 0; // for cases when first page doesn't fill the screen
+                if(!isLoading) {
+                  if (!isScreenFilled || (isNotAtStart && isAtOrNearEdge)) {
+                    filteredSearch();
+                  }
+                }
+                return true;
+              },
+            )
+          ),
+          if(isLoading && !isLastPage)
+            Container(
+              padding: EdgeInsets.only(top: 5, bottom: 5),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  CircularProgressIndicator(),
+                  const SizedBox(width: 15),
+                  Text('Loading page #${widget.searchGlobals.pageNum.toString()}')
+                ]
+              )
+            ),
+          if(isLastPage && fetched.length > 0) 
+            Center(child: Text('You Reached the End (${widget.searchGlobals.pageNum.toString()} pages)')),
+          if(isLastPage && fetched.length == 0)
+            Expanded(child:Center(child: Text('No Data Loaded'))),
+        ],
+      )
+    );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,6 +26,7 @@ dependencies:
   dio: ^4.0.0-beta6
   xml: ^5.0.2
   flutter_launcher_icons: ^0.9.0
+  vibration: ^1.7.4-nullsafety.0
   get: ^4.0.0-nullsafety.2
   permission_handler: ^6.0.0
   image: ^3.0.1
@@ -34,7 +35,7 @@ dependencies:
     git:
       url: "https://github.com/NANI-SORE/photo_view.git"
   html: ^0.15.0
-  #flutter_staggered_grid_view: ^0.3.4
+  # flutter_staggered_grid_view: ^0.3.4
   flutter_staggered_grid_view: ^0.4.0-nullsafety.3
   video_player: ^2.0.0
   chewie: ^1.0.0


### PR DESCRIPTION
Features:
- tag filtering (add your hated and loved tags and they will get marked in the grid and tags list, images with hated tags can be either blocked on load or removed completely from the list with separate setting)
- reworked loading of new pages
- pull to refresh
- navigation with volume buttons in viewer
- change toolbar position in viewer (it's also transparent now)
- now sample images get saved in separate cache folder and have no blur in viewer
- cache stats in behavior menu
- thumbnails fade in after loading
- attempt to fix staggered view
[Note]: It's still very unstable and boorus which don't provide data about image sizes will fallback to default square style

Fixes:
- memory use improvements
- restored longpress logic on share button
- fixed suggestions on paheal
- improved detection of already favourited items
- search history duplicates fix

... and more ...