### PR TITLE
(TEST BEFORE ACCEPTING) Properly resolve Hydrus parents/siblings (#56)

### DIFF
--- a/lib/libBooru/HydrusHandler.dart
+++ b/lib/libBooru/HydrusHandler.dart
@@ -88,8 +88,8 @@ class HydrusHandler extends BooruHandler{
             for (int i = 0; i < parsedResponse['metadata'].length; i++){
                 List<String> tagList = [];
                 var responseTags;
-                if (parsedResponse['metadata'][i]['service_names_to_statuses_to_tags']['all known tags'] != null){
-                  responseTags = (parsedResponse['metadata'][i]['service_names_to_statuses_to_tags']['all known tags']['0'] == null) ? parsedResponse['metadata'][i]['service_names_to_statuses_to_tags']['all known tags']['1'] : parsedResponse['metadata'][i]['service_names_to_statuses_to_tags']['all known tags']['0'];
+                if (parsedResponse['metadata'][i]['service_names_to_statuses_to_display_tags ']['all known tags'] != null){
+                  responseTags = (parsedResponse['metadata'][i]['service_names_to_statuses_to_display_tags ']['all known tags']['0'] == null) ? parsedResponse['metadata'][i]['service_names_to_statuses_to_display_tags ']['all known tags']['1'] : parsedResponse['metadata'][i]['service_names_to_statuses_to_display_tags ']['all known tags']['0'];
                 }
                 if (responseTags != null){
                   for (int x = 0; x < responseTags.length; x++){


### PR DESCRIPTION
**PLEASE TEST BEFORE ACCEPTING.  DID NOT TEST.  MAY BREAK HYDRUS IF LEFT UNTESTED.**
_It's only 4 variables changed. Simple to revert but if pushed to a release, it will take a while for the fixed version to be pushed to Izzy's F-Droid repo and any users of the app from that repo will be stuck with a release with broken Hydrus. I just don't have the time to figure out how to build a test apk._

**This was suggested in issue #56 to properly discern and resolve between siblings/parents tags.**
_"The app should use the service_names_to_statuses_to_display_tags object in the file metadata response for tags to display and use in autocomplete rather than the service_names_to_statuses_to_tags object it currently uses. The one currently being used contains the raw tags of the file where service_names_to_statuses_to_display_tags will have resolved siblings and parents."_

**This could be extended** by making this an option that the user can choose to use either `service_names_to_statuses_to_tags`  or `service_names_to_statuses_to_display_tags` as they please.