### PR TITLE
fix boorus that have spaces in file_url

### DIFF
--- a/lib/src/boorus/moebooru_handler.dart
+++ b/lib/src/boorus/moebooru_handler.dart
@@ -55,7 +55,7 @@ class MoebooruHandler extends BooruHandler {
       }
 
       BooruItem item = BooruItem(
-        fileURL: fileURL,
+        fileURL: fileURL.replaceAll(' ', '%20'),
         sampleURL: sampleURL,
         thumbnailURL: previewURL,
         tagsList: current.getAttribute("tags")!.split(" "),


### PR DESCRIPTION
lolibooru has spaces in the file url that are annoying to deal with when file url is copied. may affect other boorus. but only lolibooru I have come across. this was the most unobtrusive way I could get it to work reliably.