### PR TITLE
Feat: adjustable desktop scroll

### DIFF
--- a/lib/src/handlers/settings_handler.dart
+++ b/lib/src/handlers/settings_handler.dart
@@ -92,6 +92,8 @@ class SettingsHandler extends GetxController {
   int galleryAutoScrollTime = 4000;
   int cacheSize = 3;
 
+  double desktopmodifierScrollSpeed = 10.0;
+
   int currentColumnCount(BuildContext context) {
     return MediaQuery.of(context).orientation == Orientation.portrait
         ? portraitColumns
@@ -164,6 +166,7 @@ class SettingsHandler extends GetxController {
     'thumbnailCache', 'mediaCache',
     'dbEnabled', 'searchHistoryEnabled',
     'useVolumeButtonsForScroll', 'volumeButtonsScrollSpeed',
+    'desktopmodifierScrollSpeed' , 
     'prefBooru', 'appMode', 'handSide', 'extPathOverride',
     'lastSyncIp', 'lastSyncPort',
     'theme', 'themeMode', 'isAmoled', 'useMaterial3', 'useDynamicColor',
@@ -302,6 +305,12 @@ class SettingsHandler extends GetxController {
       "default": 200,
       "upperLimit": 1000000,
       "lowerLimit": 0,
+    },
+    "desktopmodifierScrollSpeed": {
+      "type": "double",
+      "default": 10.0,
+      "upperLimit": 20.0,
+      "lowerLimit": 0.1,
     },
     "galleryAutoScrollTime": {
       "type": "int",
@@ -756,6 +765,8 @@ class SettingsHandler extends GetxController {
         return useVolumeButtonsForScroll;
       case 'volumeButtonsScrollSpeed':
         return volumeButtonsScrollSpeed;
+      case 'desktopModifierScrollSpeed':
+        return desktopmodifierScrollSpeed;
       case 'disableVideo':
         return disableVideo;
       case 'shitDevice':
@@ -912,6 +923,9 @@ class SettingsHandler extends GetxController {
       case 'volumeButtonsScrollSpeed':
         volumeButtonsScrollSpeed = validatedValue;
         break;
+      case 'desktopmodifierScrollSpeed':
+        desktopmodifierScrollSpeed = validatedValue;
+        break;
       case 'disableVideo':
         disableVideo = validatedValue;
         break;
@@ -1040,6 +1054,7 @@ class SettingsHandler extends GetxController {
       "filterFavourites" : validateValue("filterFavourites", null, toJSON: true),
       "useVolumeButtonsForScroll" : validateValue("useVolumeButtonsForScroll", null, toJSON: true),
       "volumeButtonsScrollSpeed" : validateValue("volumeButtonsScrollSpeed", null, toJSON: true),
+      "desktopModifierScrollSpeed" : validateValue("desktopModifierScrollSpeed", null, toJSON: true),
       "disableVideo" : validateValue("disableVideo", null, toJSON: true),
       "shitDevice" : validateValue("shitDevice", null, toJSON: true),
       "galleryAutoScrollTime" : validateValue("galleryAutoScrollTime", null, toJSON: true),

--- a/lib/src/handlers/settings_handler.dart
+++ b/lib/src/handlers/settings_handler.dart
@@ -92,7 +92,7 @@ class SettingsHandler extends GetxController {
   int galleryAutoScrollTime = 4000;
   int cacheSize = 3;
 
-  double desktopmodifierScrollSpeed = 10.0;
+  double mousewheelScrollSpeed = 10.0;
 
   int currentColumnCount(BuildContext context) {
     return MediaQuery.of(context).orientation == Orientation.portrait
@@ -166,7 +166,7 @@ class SettingsHandler extends GetxController {
     'thumbnailCache', 'mediaCache',
     'dbEnabled', 'searchHistoryEnabled',
     'useVolumeButtonsForScroll', 'volumeButtonsScrollSpeed',
-    'desktopmodifierScrollSpeed' , 
+    'mousewheelScrollSpeed' , 
     'prefBooru', 'appMode', 'handSide', 'extPathOverride',
     'lastSyncIp', 'lastSyncPort',
     'theme', 'themeMode', 'isAmoled', 'useMaterial3', 'useDynamicColor',
@@ -306,7 +306,7 @@ class SettingsHandler extends GetxController {
       "upperLimit": 1000000,
       "lowerLimit": 0,
     },
-    "desktopmodifierScrollSpeed": {
+    "mousewheelScrollSpeed": {
       "type": "double",
       "default": 10.0,
       "upperLimit": 20.0,
@@ -765,8 +765,8 @@ class SettingsHandler extends GetxController {
         return useVolumeButtonsForScroll;
       case 'volumeButtonsScrollSpeed':
         return volumeButtonsScrollSpeed;
-      case 'desktopModifierScrollSpeed':
-        return desktopmodifierScrollSpeed;
+      case 'mousewheelScrollSpeed':
+        return mousewheelScrollSpeed;
       case 'disableVideo':
         return disableVideo;
       case 'shitDevice':
@@ -923,8 +923,8 @@ class SettingsHandler extends GetxController {
       case 'volumeButtonsScrollSpeed':
         volumeButtonsScrollSpeed = validatedValue;
         break;
-      case 'desktopmodifierScrollSpeed':
-        desktopmodifierScrollSpeed = validatedValue;
+      case 'mousewheelScrollSpeed':
+        mousewheelScrollSpeed = validatedValue;
         break;
       case 'disableVideo':
         disableVideo = validatedValue;
@@ -1054,7 +1054,7 @@ class SettingsHandler extends GetxController {
       "filterFavourites" : validateValue("filterFavourites", null, toJSON: true),
       "useVolumeButtonsForScroll" : validateValue("useVolumeButtonsForScroll", null, toJSON: true),
       "volumeButtonsScrollSpeed" : validateValue("volumeButtonsScrollSpeed", null, toJSON: true),
-      "desktopModifierScrollSpeed" : validateValue("desktopModifierScrollSpeed", null, toJSON: true),
+      "mousewheelScrollSpeed" : validateValue("mousewheelScrollSpeed", null, toJSON: true),
       "disableVideo" : validateValue("disableVideo", null, toJSON: true),
       "shitDevice" : validateValue("shitDevice", null, toJSON: true),
       "galleryAutoScrollTime" : validateValue("galleryAutoScrollTime", null, toJSON: true),

--- a/lib/src/pages/settings/gallery_page.dart
+++ b/lib/src/pages/settings/gallery_page.dart
@@ -20,7 +20,7 @@ class _GalleryPageState extends State<GalleryPage> {
 
   TextEditingController preloadController = TextEditingController();
   TextEditingController scrollSpeedController = TextEditingController();
-  TextEditingController desktopSpeedController = TextEditingController();
+  TextEditingController mouseSpeedController = TextEditingController();
   TextEditingController galleryAutoScrollController = TextEditingController();
 
   @override
@@ -39,7 +39,7 @@ class _GalleryPageState extends State<GalleryPage> {
     autoPlay = settingsHandler.autoPlayEnabled;
     useVolumeButtonsForScroll = settingsHandler.useVolumeButtonsForScroll;
     scrollSpeedController.text = settingsHandler.volumeButtonsScrollSpeed.toString();
-    desktopSpeedController.text = settingsHandler.desktopmodifierScrollSpeed.toString();
+    mouseSpeedController.text = settingsHandler.mousewheelScrollSpeed.toString();
     galleryAutoScrollController.text = settingsHandler.galleryAutoScrollTime.toString();
     preloadController.text = settingsHandler.preloadCount.toString();
     shitDevice = settingsHandler.shitDevice;
@@ -72,7 +72,7 @@ class _GalleryPageState extends State<GalleryPage> {
       galleryAutoScrollController.text = "800";
     }
     settingsHandler.volumeButtonsScrollSpeed = int.parse(scrollSpeedController.text);
-    settingsHandler.desktopmodifierScrollSpeed = double.parse(desktopSpeedController.text);
+    settingsHandler.mousewheelScrollSpeed = double.parse(mouseSpeedController.text);
     settingsHandler.galleryAutoScrollTime = int.parse(galleryAutoScrollController.text);
     if (int.parse(preloadController.text) < 0){
       preloadController.text = 0.toString();
@@ -457,14 +457,14 @@ class _GalleryPageState extends State<GalleryPage> {
                 }
               ),
               SettingsTextInput(
-                controller: desktopSpeedController,
-                title: 'Desktop Scroll modifer',
+                controller: mouseSpeedController,
+                title: 'Mouse Wheel Scroll Modifer',
                 hintText: "Scroll modifier",
                 inputType: TextInputType.number,
                 inputFormatters: <TextInputFormatter>[
                   FilteringTextInputFormatter.digitsOnly
                 ],
-                resetText: () => settingsHandler.map['desktopmodifierScrollSpeed']!['default']!.toString(),
+                resetText: () => settingsHandler.map['mousewheelScrollSpeed']!['default']!.toString(),
                 numberButtons: true,
                 numberStep: 0.5,
                 numberMin: 0.1,

--- a/lib/src/pages/settings/gallery_page.dart
+++ b/lib/src/pages/settings/gallery_page.dart
@@ -20,6 +20,7 @@ class _GalleryPageState extends State<GalleryPage> {
 
   TextEditingController preloadController = TextEditingController();
   TextEditingController scrollSpeedController = TextEditingController();
+  TextEditingController desktopSpeedController = TextEditingController();
   TextEditingController galleryAutoScrollController = TextEditingController();
 
   @override
@@ -38,6 +39,7 @@ class _GalleryPageState extends State<GalleryPage> {
     autoPlay = settingsHandler.autoPlayEnabled;
     useVolumeButtonsForScroll = settingsHandler.useVolumeButtonsForScroll;
     scrollSpeedController.text = settingsHandler.volumeButtonsScrollSpeed.toString();
+    desktopSpeedController.text = settingsHandler.desktopmodifierScrollSpeed.toString();
     galleryAutoScrollController.text = settingsHandler.galleryAutoScrollTime.toString();
     preloadController.text = settingsHandler.preloadCount.toString();
     shitDevice = settingsHandler.shitDevice;
@@ -70,6 +72,7 @@ class _GalleryPageState extends State<GalleryPage> {
       galleryAutoScrollController.text = "800";
     }
     settingsHandler.volumeButtonsScrollSpeed = int.parse(scrollSpeedController.text);
+    settingsHandler.desktopmodifierScrollSpeed = double.parse(desktopSpeedController.text);
     settingsHandler.galleryAutoScrollTime = int.parse(galleryAutoScrollController.text);
     if (int.parse(preloadController.text) < 0){
       preloadController.text = 0.toString();
@@ -448,6 +451,32 @@ class _GalleryPageState extends State<GalleryPage> {
                     return 'Please enter a valid numeric value';
                   } else if(parse < 100) {
                     return 'Please enter a value bigger than 100';
+                  } else {
+                    return null;
+                  }
+                }
+              ),
+              SettingsTextInput(
+                controller: desktopSpeedController,
+                title: 'Desktop Scroll modifer',
+                hintText: "Scroll modifier",
+                inputType: TextInputType.number,
+                inputFormatters: <TextInputFormatter>[
+                  FilteringTextInputFormatter.digitsOnly
+                ],
+                resetText: () => settingsHandler.map['desktopmodifierScrollSpeed']!['default']!.toString(),
+                numberButtons: true,
+                numberStep: 0.5,
+                numberMin: 0.1,
+                numberMax: 20.0,
+                validator: (String? value) {
+                  double? parse = double.tryParse(value ?? '');
+                  if(value == null || value.isEmpty) {
+                    return 'Please enter a value';
+                  } else if(parse == null) {
+                    return 'Please enter a valid numeric value';
+                  } else if(parse > 20.0) {
+                    return 'Please enter a value between 0.1 and 20.0';
                   } else {
                     return null;
                   }

--- a/lib/src/widgets/desktop/desktop_scroll_wrap.dart
+++ b/lib/src/widgets/desktop/desktop_scroll_wrap.dart
@@ -24,6 +24,7 @@ class DesktopScrollWrap extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final SettingsHandler settingsHandler = SettingsHandler.instance;
     // set physics to:
     // (Platform.isWindows || Platform.isLinux || Platform.isMacOS) ? const NeverScrollableScrollPhysics() : null,
     // on child element wrapped in this
@@ -60,8 +61,10 @@ class DesktopScrollWrap extends StatelessWidget {
             return const Duration(milliseconds: 2000);
           },
         ),
-        customMouseWheelScrollConfig: const CustomMouseWheelScrollConfig(
-          scrollAmountMultiplier: 10.0,
+        customMouseWheelScrollConfig: CustomMouseWheelScrollConfig(
+          scrollAmountMultiplier: SettingsHandler.instance.appMode.value.isDesktop == true 
+          ? (settingsHandler.desktopmodifierScrollSpeed / 5) 
+          : settingsHandler.desktopmodifierScrollSpeed,
         ),
         child: child,
       );

--- a/lib/src/widgets/desktop/desktop_scroll_wrap.dart
+++ b/lib/src/widgets/desktop/desktop_scroll_wrap.dart
@@ -63,8 +63,8 @@ class DesktopScrollWrap extends StatelessWidget {
         ),
         customMouseWheelScrollConfig: CustomMouseWheelScrollConfig(
           scrollAmountMultiplier: SettingsHandler.instance.appMode.value.isDesktop == true 
-          ? (settingsHandler.desktopmodifierScrollSpeed / 5) 
-          : settingsHandler.desktopmodifierScrollSpeed,
+          ? (settingsHandler.mousewheelScrollSpeed / 3) 
+          : settingsHandler.mousewheelScrollSpeed,
         ),
         child: child,
       );


### PR DESCRIPTION
Not totally happy with the below code since the width of the view can change how fast it scrolls however this should be a good start and helps usability quite a bit if you swap between desktop and mobile (I plan on submitting a PR in the future sometime that will allow selecting "Hybrid" which will change UI depending on aspect ratio which can help a lot with two in one devices)

```dart
scrollAmountMultiplier: SettingsHandler.instance.appMode.value.isDesktop == true 
          ? (settingsHandler.mousewheelScrollSpeed / 3) 
          : settingsHandler.mousewheelScrollSpeed,
        ),
```