### PR TITLE
Add rule34.us support

### DIFF
--- a/lib/src/boorus/booru_type.dart
+++ b/lib/src/boorus/booru_type.dart
@@ -19,6 +19,7 @@ enum BooruType {
   Philomena,
   Rainbooru,
   R34Hentai,
+  R34US,
   Sankaku,
   IdolSankaku,
   Shimmie,

--- a/lib/src/handlers/booru_handler_factory.dart
+++ b/lib/src/handlers/booru_handler_factory.dart
@@ -18,6 +18,7 @@ import 'package:lolisnatcher/src/boorus/nyanpals_handler.dart';
 import 'package:lolisnatcher/src/boorus/philomena_handler.dart';
 import 'package:lolisnatcher/src/boorus/r34hentai_handler.dart';
 import 'package:lolisnatcher/src/boorus/rainbooru_handler.dart';
+import 'package:lolisnatcher/src/boorus/r34us_handler.dart';
 import 'package:lolisnatcher/src/boorus/sankaku_handler.dart';
 import 'package:lolisnatcher/src/boorus/shimmie_handler.dart';
 import 'package:lolisnatcher/src/boorus/szurubooru_handler.dart';
@@ -83,6 +84,10 @@ class BooruHandlerFactory {
           break;
         case BooruType.Szurubooru:
           booruHandler = SzurubooruHandler(booru, limit);
+          break;
+        case BooruType.R34US:
+          pageNum = 0;
+          booruHandler = R34USHandler(booru, limit);
           break;
         case BooruType.Sankaku:
           pageNum = 0;

--- a/lib/src/pages/settings/booru_edit_page.dart
+++ b/lib/src/pages/settings/booru_edit_page.dart
@@ -291,6 +291,10 @@ class _BooruEditState extends State<BooruEdit> {
           booruFaviconController.text = 'https://agn.ph/skin/Retro/favicon.ico';
         }
 
+        if (booruURLController.text.contains('rule34.us')) {
+          booruFaviconController.text = '${booruURLController.text}/favicon.png';
+        }
+
         // some boorus have their api url different from main host
         booruURLController.text = convertSiteUrlToApi();
 

--- a/lib/src/widgets/video/guess_extension_viewer.dart
+++ b/lib/src/widgets/video/guess_extension_viewer.dart
@@ -86,9 +86,11 @@ class _GuessExtensionViewerState extends State<GuessExtensionViewer> {
       possibleExtensions = [...gifExtensions, ...videoExtensions, ...imageExtensions];
     } else if (widget.item.possibleMediaType.value?.isVideo == true) {
       possibleExtensions = [...videoExtensions, ...imageExtensions, ...gifExtensions];
-    } else {
+    } else if (widget.item.fileURL.contains('realbooru.com')) {
       // videos are still in front because realbooru can have both image (video thumbnail) and video under same url (minus extension)
       possibleExtensions = [...videoExtensions, ...imageExtensions, ...gifExtensions];
+    } else {
+      possibleExtensions = [...imageExtensions, ...gifExtensions, ...videoExtensions];
     }
 
     for (final String extension in possibleExtensions) {

--- a/test/booru_test.dart
+++ b/test/booru_test.dart
@@ -14,6 +14,7 @@ import 'package:lolisnatcher/src/boorus/moebooru_handler.dart';
 import 'package:lolisnatcher/src/boorus/nyanpals_handler.dart';
 import 'package:lolisnatcher/src/boorus/philomena_handler.dart';
 import 'package:lolisnatcher/src/boorus/rainbooru_handler.dart';
+import 'package:lolisnatcher/src/boorus/r34us_handler.dart';
 import 'package:lolisnatcher/src/boorus/sankaku_handler.dart';
 import 'package:lolisnatcher/src/boorus/shimmie_handler.dart';
 import 'package:lolisnatcher/src/boorus/szurubooru_handler.dart';
@@ -106,11 +107,10 @@ Future<void> main() async {
       final BooruHandler booruHandler = await testBooru(Booru('r34hentai', BooruType.R34Hentai, '', 'https://r34hentai.com', ''));
       expect(booruHandler, isA<PhilomenaHandler>());
     });
-    //Not in the factory?
-    /*test('R34USHandler', () async {
-      BooruHandler booruHandler = await testBooru(Booru("r34US", "R34US","","https://rule34.us",""));
+    test('R34USHandler', () async {
+      final BooruHandler booruHandler = await testBooru(Booru('r34US', BooruType.R34US, '', 'https://rule34.us', ''));
       expect(booruHandler, isA<R34USHandler>());
-    });*/
+    });
     test('SankakuHandler', () async {
       // TODO doesn't parse all items correctly?
       final BooruHandler booruHandler = await testBooru(Booru('sankaku', BooruType.Sankaku, '', 'https://capi-v2.sankakucomplex.com', ''));


### PR DESCRIPTION
Continued working on the r34us handler to turn it into a usable state. There's still some weird issue happening where some of the thumbs start flashing and giving "ERROR Tap to retry! 404" when you scroll down a few pages and back up to the top. The posts load fine however, when you try to open them. I've also not added tag type support or auto suggestions. and there are still some missing fields like uploader, score etc.  

The thumb URLs are converted to full URL using the guess extension function. I modified the guessing logic slightly to speed up the guessing process because the realbooru `possibleExtensions ` was slowing it down.