### PR TITLE
Support for refreshing Sankaku Idol Favorites Image URLs

### DIFF
--- a/lib/src/pages/settings/database_page.dart
+++ b/lib/src/pages/settings/database_page.dart
@@ -113,12 +113,12 @@ class _DatabasePageState extends State<DatabasePage> {
     final List<Booru> sankakuBoorus = [];
 
     for (int i = 0; i < settingsHandler.booruList.length; i++) {
-      if (settingsHandler.booruList[i].type?.isSankaku == true &&
+      if ((settingsHandler.booruList[i].type?.isSankaku == true || settingsHandler.booruList[i].type?.isIdolSankaku == true) &&
           [
             ...SankakuHandler.knownUrls,
+            ...IdolSankakuHandler.knownUrls,
             'sankakuapi.com',
           ].any((e) => settingsHandler.booruList[i].baseURL?.contains(e) ?? false)) {
-        // TODO add support for idol (if possible, it seems that idol uses old api which doesn't allow item refresh (parse html then?))
         sankakuBoorus.add(settingsHandler.booruList[i]);
       }
     }


### PR DESCRIPTION
Parses the html from the actual post for the file url, sample url (defaults to file url if not found), and thumbnail url allowing refresh sankaku thumbnails to work on idol favorites.

Not sure if there is anything else that needs to be changed for this. As far as I can tell it works at least on the posts I was having this issue with. (#285)

I'm not a mobile/web dev so there may be a better way to do this.