### PR TITLE
Hydrus | fix url encoding spacing

### DIFF
--- a/lib/src/boorus/hydrus_handler.dart
+++ b/lib/src/boorus/hydrus_handler.dart
@@ -288,22 +288,23 @@ class HydrusHandler extends BooruHandler {
     if (tags.trim().isEmpty) {
       tags = '*';
     }
-    final List<String> tagList = tags.split(',');
+    final List<String> tagList = tags.split(',').map((tag) => tag.trim()).toList();
     int sortType = -1;
     bool ascending = false;
     for (int i = tagList.length - 1; i >= 0; i--) {
       if (tagList[i].contains('sort:')) {
-        sortType = getSortType(tagList[i].split(':')[1]);
-        tagList.remove(tagList[i].trim().toLowerCase());
+        sortType = getSortType(tagList[i].split(':')[1].trim());
+        tagList.removeAt(i);
       } else if (tagList[i].contains('order:asc')) {
         ascending = true;
-        tagList.remove(tagList[i].trim().toLowerCase());
+        tagList.removeAt(i);
       } else if (tagList[i].contains('order:desc')) {
         ascending = false;
-        tagList.remove(tagList[i].trim().toLowerCase());
+        tagList.removeAt(i);
       }
     }
-    return "${booru.baseURL}/get_files/search_files?tags=${jsonEncode(tagList).replaceAll("%22", "'")}${sortType > -1 ? "&file_sort_type=$sortType" : ""}&file_sort_asc=$ascending";
+    final String encodedTags = Uri.encodeComponent(jsonEncode(tagList));
+    return "${booru.baseURL}/get_files/search_files?tags=$encodedTags${sortType > -1 ? "&file_sort_type=$sortType" : ""}&file_sort_asc=$ascending";
   }
 
   int getSortType(String orderString) {


### PR DESCRIPTION
parsing sucked. standard comma+space separation. 
while updating issue #362, i noticed searches like "system:archive,sort:duration,fur,order:asc,system:has duration" worked fine, and gave hints of faulty URL encoding. this patch fixes that, and keeps the old non-spaced searches intact for people with 1000 tagged searches.

spaces in between tags would be included in at least one of the two, breaking hydrus' api. 

our test search for tonight: "system:archive, fur, sort:duration, order:desc, system:has duration"
would be sent to the hydrus API as:
["system:archive","+fur","+system:has+duration"]

this patch makes it not do that.
["system:archive","fur","system:has+duration"]

this also partially fixes sort and order tags' ambiguity, and makes the search bar slightly prettier when full of spaces. still not separated by commas, though, so "system:has duration," is two different tags according to the search bar.