### PR TITLE
Hydrus | OR query handling

### DIFF
--- a/lib/src/boorus/hydrus_handler.dart
+++ b/lib/src/boorus/hydrus_handler.dart
@@ -283,28 +283,41 @@ class HydrusHandler extends BooruHandler {
     return '';
   }
 
-  @override
+@override
   String makeURL(String tags) {
     if (tags.trim().isEmpty) {
       tags = '*';
     }
-    final List<String> tagList = tags.split(',').map((tag) => tag.trim()).toList();
+
     int sortType = -1;
     bool ascending = false;
-    for (int i = tagList.length - 1; i >= 0; i--) {
-      if (tagList[i].contains('sort:')) {
-        sortType = getSortType(tagList[i].split(':')[1].trim());
-        tagList.removeAt(i);
-      } else if (tagList[i].contains('order:asc')) {
+
+    final List<String> parts = tags.split(',').map((t) => t.trim()).toList();
+
+    final List<String> filteredParts = [];
+    for (final part in parts) {
+      if (part.startsWith('sort:')) {
+        sortType = getSortType(part.substring(5).trim());
+      } else if (part == 'order:asc') {
         ascending = true;
-        tagList.removeAt(i);
-      } else if (tagList[i].contains('order:desc')) {
+      } else if (part == 'order:desc') {
         ascending = false;
-        tagList.removeAt(i);
+      } else {
+        filteredParts.add(part);
       }
     }
+
+    final List<dynamic> tagList = filteredParts.map((part) {
+      if (part.contains(' OR ')) {
+        return part.split(' OR ').map((t) => t.trim()).toList();
+      }
+      return part;
+    }).toList();
+
     final String encodedTags = Uri.encodeComponent(jsonEncode(tagList));
-    return "${booru.baseURL}/get_files/search_files?tags=$encodedTags${sortType > -1 ? "&file_sort_type=$sortType" : ""}&file_sort_asc=$ascending";
+    return '${booru.baseURL}/get_files/search_files?tags=$encodedTags'
+        '${sortType > -1 ? "&file_sort_type=$sortType" : ""}'
+        '&file_sort_asc=$ascending';
   }
 
   int getSortType(String orderString) {


### PR DESCRIPTION
introduces OR queries into hydrus' handler.

query: system:archive, tag1 OR tag2, tag3

what previously GETs:
["system:archive", "tag1",  "OR", "tag2", "tag3"]

now GETs:
["system:archive", ["tag1", "tag2"], "tag3"]

'OR' is used over '~' in hydrus' client, and as such, is mirrored here. this also allows for multiple nested OR searches, like:

system:archive, tag1 OR tag2 OR tag3, tag4, tag5 OR tag6
returning...
["system:archive", ["tag1", "tag2", "tag3"], "tag4", ["tag5", "tag6"]]