### PR TITLE
Add urljoin to tools.dart

### DIFF
--- a/lib/src/utils/tools.dart
+++ b/lib/src/utils/tools.dart
@@ -416,4 +416,33 @@ class Tools {
   }
 }
 
+  static String? urlJoin(String? base, String? segment) {
+    if (base == null) return segment;
+    if (segment == null) return base;
+
+    final baseUri = Uri.parse(base), segUri = Uri.parse(segment);
+    final schemeRegex = RegExp(r'^[a-zA-Z][a-zA-Z\d+\-.]*:');
+    if (schemeRegex.hasMatch(segment)) return segment;
+    if (segment.startsWith('//')) return '${baseUri.scheme}:$segment';
+    if (segment.startsWith('?')) return baseUri.replace(query: segUri.query, fragment: segUri.fragment).toString();
+    if (segment.startsWith('#')) return baseUri.replace(fragment: segUri.fragment).toString();
+
+    var path = baseUri.path.endsWith('/') ? baseUri.path : baseUri.path.substring(0, baseUri.path.lastIndexOf('/') + 1);
+    if (segment.startsWith('/')) {
+      path = segment.substring(1);
+    } else {
+      path += segUri.path;
+    }
+
+    return Uri(
+      scheme: baseUri.scheme,
+      host: baseUri.host,
+      port: baseUri.hasPort ? baseUri.port : null,
+      path: path,
+      query: segUri.query.isEmpty ? null : segUri.query,
+      fragment: segUri.fragment.isEmpty ? null : segUri.fragment,
+    ).toString();
+  }
+}
+
 bool captchaScreenActive = false;

--- a/test/tools_test.dart
+++ b/test/tools_test.dart
@@ -1,0 +1,69 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lolisnatcher/src/utils/tools.dart';
+
+Future<void> main() async {
+  group('Tools.urlJoin', () {
+    test('joins relative path correctly', () async {
+      expect(
+        Tools.urlJoin('http://example.com/folder/file.html', 'next.html'),
+        'http://example.com/folder/next.html',
+      );
+    });
+
+    test('replaces path if segment starts with /', () async {
+      expect(
+        Tools.urlJoin('http://example.com/folder/file.html', '/new/path.html'),
+        'http://example.com/new/path.html',
+      );
+    });
+
+    test('returns segment if base is null', () async {
+      expect(
+        Tools.urlJoin(null, '/path'),
+        '/path',
+      );
+    });
+
+    test('returns base if segment is null', () async {
+      expect(
+        Tools.urlJoin('https://example.com', null),
+        'https://example.com',
+      );
+    });
+
+    test('keeps port numbers', () async {
+      expect(
+        Tools.urlJoin('http://example.com:8080/folder/', 'next.html'),
+        'http://example.com:8080/folder/next.html',
+      );
+    });
+
+    test('handles double slashes segment like Python urljoin', () async {
+      expect(
+        Tools.urlJoin('http://example.com/folder/file.html', '//other.com/path'),
+        'http://other.com/path',
+      );
+    });
+
+    test('keeps query and fragment from base when joining relative', () async {
+      expect(
+        Tools.urlJoin('http://example.com/folder/?q=1#frag', 'next.html'),
+        'http://example.com/folder/next.html',
+      );
+    });
+
+    test('joins relative path with query and fragment', () async {
+      expect(
+        Tools.urlJoin('http://example.com/folder/next.html', 'page.html?q=1#frag'),
+        'http://example.com/folder/page.html?q=1#frag',
+      );
+    });
+
+    test('replaces only query and fragment on same path', () async {
+      expect(
+        Tools.urlJoin('http://example.com/folder/next.html', '?q=1#frag'),
+        'http://example.com/folder/next.html?q=1#frag',
+      );
+    });
+  });
+}


### PR DESCRIPTION
Based on Python's [urllib.parse.urljoin](https://docs.python.org/3/library/urllib.parse.html#urllib.parse.urljoin)

Example:
```java
Tools.urlJoin('http://example.com/folder/file.html', '/new/path.html');
// 'http://example.com/new/path.html'
```